### PR TITLE
Fix drawing of planet layers

### DIFF
--- a/source/CIPlanetNode.cpp
+++ b/source/CIPlanetNode.cpp
@@ -13,6 +13,8 @@
 #include "CIPlanetNode.h"
 #include <cugl/cugl.h>
 
+#define LOCK_IN_SCALE_DOWN  .75
+
 void PlanetNode::draw(const std::shared_ptr<cugl::SpriteBatch>& batch,
           const cugl::Mat4& transform, cugl::Color4 tint) {
     PolygonNode::draw(batch,transform, tint);
@@ -29,15 +31,29 @@ void PlanetNode::setLayers(std::vector<PlanetLayer>* layers) {
         LayerNode* node = &_layerNodes[ii];
         if (layers->at(ii).isActive) {
             if (node->innerRing == nullptr) {
+                if (ii > 0) {
+                    // decrease size of locked in layer slightly
+                    if (ii == 1) {
+                        _coreScale *= .8;
+                        setScale(_coreScale);
+                    }
+                    LayerNode* prev = &_layerNodes[ii-1];
+                    prev->innerRing->setScale(_layerScale*LOCK_IN_SCALE_DOWN/_coreScale);
+                    prev->outerRing->setScale(_layerScale*LOCK_IN_SCALE_DOWN/_coreScale);
+                }
+                
                 node->innerRing = cugl::scene2::PolygonNode::allocWithTexture(_ringTexture);
                 node->outerRing = cugl::scene2::PolygonNode::allocWithTexture(_unlockedTexture);
                 
                 node->innerRing->setAnchor(cugl::Vec2::ANCHOR_CENTER);
                 node->outerRing->setAnchor(cugl::Vec2::ANCHOR_CENTER);
-                node->innerRing->setPosition(cugl::Vec2(getSize())*0.5f);
-                node->outerRing->setPosition(cugl::Vec2(getSize())*0.5f);
+                cugl::Vec2 pos = cugl::Vec2(getTexture()->getSize()) * 0.5f;
+                node->innerRing->setPosition(pos);
+                node->outerRing->setPosition(pos);
                 node->innerRing->setRelativeColor(false);
                 node->outerRing->setRelativeColor(false);
+                node->innerRing->setScale(_layerScale/_coreScale);
+                node->outerRing->setScale(_layerScale/_coreScale);
                 
                 addChild(node->innerRing);
                 addChild(node->outerRing);

--- a/source/CIPlanetNode.h
+++ b/source/CIPlanetNode.h
@@ -16,7 +16,7 @@
 #include "CIColor.h"
 #include "CIPlanetLayer.h"
 
-#define PLANET_RING_SCALE     0.28f
+#define PLANET_RING_TEXTURE_INNER_SIZE 480
 
 class PlanetNode : public cugl::scene2::PolygonNode {
 private:
@@ -28,8 +28,10 @@ private:
         std::shared_ptr<cugl::scene2::PolygonNode> outerRing;
     };
     
-    /** Radius of the planet in pixels */
-    float _radius;
+    /** The scaling factor of the core */
+    float _coreScale;
+    /** The scaling factor of the outermost layer */
+    float _layerScale;
     
     /** The layers of this planet */
     std::vector<PlanetLayer>* _layers;
@@ -66,14 +68,17 @@ public:
     void setLayers(std::vector<PlanetLayer>* layers);
     
     void setRadius(float r) {
-        _radius = r;
-        float scale = _radius * 0.02f;
-        setScale(scale);
-        for (int ii = 0; ii < _layerNodes.size(); ii++) {
-            LayerNode node = _layerNodes[ii];
-            if (node.innerRing != nullptr) {
-                node.innerRing->setScale(PLANET_RING_SCALE);
-                node.outerRing->setScale(PLANET_RING_SCALE);
+        _layerScale = (2 * r) / _ringTexture->getWidth();
+        for (int ii = (int)(_layerNodes.size())-1; ii >= 0; ii--) {
+            LayerNode* node = &_layerNodes[ii];
+            if (node->innerRing != nullptr) {
+                if (ii == 0) {
+                    _coreScale = (2 * r * PLANET_RING_TEXTURE_INNER_SIZE) / (_ringTexture->getWidth() * getTexture()->getWidth());
+                    setScale(_coreScale);
+                }
+                node->innerRing->setScale(_layerScale/_coreScale);
+                node->outerRing->setScale(_layerScale/_coreScale);
+                break;
             }
         }
     }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Core Impact Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

This PR fixes the drawing of planet layers so that the display size of the planet corresponds to the radius stored in the planet model

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

* Layers shrink 25% when locked in to make visual room for the next layer
* The core scales with the first layer and shrinks with it when locked in, but does not grow afterwards
* The planet node now keeps track of its scaling factors instead of the planet radius

## Next Steps 

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

A lot of this code will need to change once we get the animations for the planet, but it should work until then

## Screenshots (delete if not applicable)

<!-- If you are making any changes to UI, you should use this section. -->

<details>

  <summary>Example of planet with multiple layers</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
  
<img width="194" alt="Screen Shot 2021-03-23 at 9 17 50 AM" src="https://user-images.githubusercontent.com/40394622/112155735-f75acb80-8bbb-11eb-81e2-7d015117103c.png">


</details>