### PR TITLE
Add model for opponent planet

### DIFF
--- a/build-apple/CoreImpact.xcodeproj/project.pbxproj
+++ b/build-apple/CoreImpact.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		CA68E30B25F53BC200B4617D /* CICollisionController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA68E30625F53BC200B4617D /* CICollisionController.cpp */; };
 		CA68E30C25F53BC200B4617D /* CICollisionController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA68E30625F53BC200B4617D /* CICollisionController.cpp */; };
 		CA68E30D25F53BC200B4617D /* CICollisionController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA68E30625F53BC200B4617D /* CICollisionController.cpp */; };
+		CA80926226123A8300599B99 /* CIOpponentPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA80926026123A8300599B99 /* CIOpponentPlanet.cpp */; };
+		CA80926326123A8300599B99 /* CIOpponentPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA80926026123A8300599B99 /* CIOpponentPlanet.cpp */; };
+		CA80926426123A8300599B99 /* CIOpponentPlanet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA80926026123A8300599B99 /* CIOpponentPlanet.cpp */; };
 		CA9A2DD125EDBD6A0048D02F /* CIStardustModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA9A2DCC25EDBD6A0048D02F /* CIStardustModel.cpp */; };
 		CA9A2DD225EDBD6A0048D02F /* CIStardustModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA9A2DCC25EDBD6A0048D02F /* CIStardustModel.cpp */; };
 		CA9A2DD325EDBD6A0048D02F /* CIStardustModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA9A2DCC25EDBD6A0048D02F /* CIStardustModel.cpp */; };
@@ -162,6 +165,8 @@
 		3DCF911D2607B5B600B97FA1 /* CINetworkUtils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CINetworkUtils.cpp; sourceTree = "<group>"; };
 		CA68E30625F53BC200B4617D /* CICollisionController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CICollisionController.cpp; sourceTree = "<group>"; };
 		CA68E30A25F53BC200B4617D /* CICollisionController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CICollisionController.h; sourceTree = "<group>"; };
+		CA80926026123A8300599B99 /* CIOpponentPlanet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CIOpponentPlanet.cpp; sourceTree = "<group>"; };
+		CA80926126123A8300599B99 /* CIOpponentPlanet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CIOpponentPlanet.h; sourceTree = "<group>"; };
 		CA9A2DC725EDBD6A0048D02F /* CIStardustModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CIStardustModel.h; sourceTree = "<group>"; };
 		CA9A2DCC25EDBD6A0048D02F /* CIStardustModel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CIStardustModel.cpp; sourceTree = "<group>"; };
 		CA9A2DCD25EDBD6A0048D02F /* CIColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CIColor.h; sourceTree = "<group>"; };
@@ -433,6 +438,8 @@
 				3DCF9118260657A900B97FA1 /* CIGameState.h */,
 				3DCF911C2607B5A100B97FA1 /* CINetworkUtils.h */,
 				3DCF911D2607B5B600B97FA1 /* CINetworkUtils.cpp */,
+				CA80926026123A8300599B99 /* CIOpponentPlanet.cpp */,
+				CA80926126123A8300599B99 /* CIOpponentPlanet.h */,
 			);
 			name = Source;
 			path = ../source;
@@ -620,6 +627,7 @@
 				CA9A2DD325EDBD6A0048D02F /* CIStardustModel.cpp in Sources */,
 				3DCF910C2606538300B97FA1 /* CINetworkMessageManager.cpp in Sources */,
 				3DCE833A25FDC3B8007EBA2D /* CIGameUpdate.cpp in Sources */,
+				CA80926426123A8300599B99 /* CIOpponentPlanet.cpp in Sources */,
 				EBFA52A221FA5D1700CCC2C5 /* CIInput.cpp in Sources */,
 				CA68E30D25F53BC200B4617D /* CICollisionController.cpp in Sources */,
 				0A5AFADB25F0B5320003669C /* CIStardustNode.cpp in Sources */,
@@ -642,6 +650,7 @@
 				EBFA52A121FA5D1700CCC2C5 /* CIInput.cpp in Sources */,
 				3DCF910B2606538300B97FA1 /* CINetworkMessageManager.cpp in Sources */,
 				CA68E30C25F53BC200B4617D /* CICollisionController.cpp in Sources */,
+				CA80926326123A8300599B99 /* CIOpponentPlanet.cpp in Sources */,
 				3DCE833925FDC3B8007EBA2D /* CIGameUpdate.cpp in Sources */,
 				0A5AFADA25F0B5320003669C /* CIStardustNode.cpp in Sources */,
 				3D563BF925F6D5B7006641B1 /* CIPlanetNode.cpp in Sources */,
@@ -664,6 +673,7 @@
 				EBFA528D21FA5AAC00CCC2C5 /* CIApp.cpp in Sources */,
 				3DCF910A2606538200B97FA1 /* CINetworkMessageManager.cpp in Sources */,
 				CA68E30B25F53BC200B4617D /* CICollisionController.cpp in Sources */,
+				CA80926226123A8300599B99 /* CIOpponentPlanet.cpp in Sources */,
 				3DCE833825FDC3B8007EBA2D /* CIGameUpdate.cpp in Sources */,
 				0A5AFAD925F0B5320003669C /* CIStardustNode.cpp in Sources */,
 				3D563BF825F6D5B7006641B1 /* CIPlanetNode.cpp in Sources */,

--- a/source/CIOpponentPlanet.cpp
+++ b/source/CIOpponentPlanet.cpp
@@ -1,0 +1,30 @@
+//
+//  CIOpponentPlanet.cpp
+//  CoreImpact
+//
+//  This class represents all the information for an opponent's planet.
+//  It makes use of the PlanetModel class, but in a degenerate case where
+//  all information is maintainted in one layer
+//
+//  Created by Brandon Stein on 3/29/21.
+//  Copyright © 2021 Game Design Initiative at Cornell. All rights reserved.
+//
+
+#include "CIOpponentPlanet.h"
+
+/**
+ * Decreases the size of the current layer
+ */
+void OpponentPlanet::decreaseLayerSize() {
+    PlanetLayer* currentLayer = &_layers[_numLayers-1];
+    if (currentLayer->layerSize > 0) {
+        currentLayer->layerSize--;
+    }
+}
+
+/**
+ * Increases the size of the current layer
+ */
+void OpponentPlanet::increaseLayerSize() {
+    _layers[_numLayers-1].layerSize++;
+}

--- a/source/CIOpponentPlanet.cpp
+++ b/source/CIOpponentPlanet.cpp
@@ -28,3 +28,12 @@ void OpponentPlanet::decreaseLayerSize() {
 void OpponentPlanet::increaseLayerSize() {
     _layers[_numLayers-1].layerSize++;
 }
+
+/**
+ * Sets the size of the current layer
+ *
+ * @param size The new size of this planet
+ */
+void OpponentPlanet::setLayerSize(int size) {
+    _layers[_numLayers-1].layerSize = size;
+}

--- a/source/CIOpponentPlanet.h
+++ b/source/CIOpponentPlanet.h
@@ -47,6 +47,13 @@ public:
      */
     void increaseLayerSize() override;
     
+    /**
+     * Sets the size of the current layer
+     *
+     * @param size The new size of this planet
+     */
+    void setLayerSize(int size);
+    
 };
 
 #endif /* __CI_OPPONENT_PLANET_H__ */

--- a/source/CIOpponentPlanet.h
+++ b/source/CIOpponentPlanet.h
@@ -1,0 +1,52 @@
+//
+//  CIOpponentPlanet.h
+//  CoreImpact
+//
+//  This class represents all the information for an opponent's planet.
+//  It makes use of the PlanetModel class, but in a degenerate case where
+//  all information is maintainted in one layer
+//
+//  Created by Brandon Stein on 3/29/21.
+//  Copyright © 2021 Game Design Initiative at Cornell. All rights reserved.
+//
+
+#ifndef __CI_OPPONENT_PLANET_H__
+#define __CI_OPPONENT_PLANET_H__
+
+#include "CIPlanetModel.h"
+
+class OpponentPlanet : public PlanetModel {
+
+public:
+#pragma mark Constructors
+    /**
+     * Returns a newly allocated opponent planet with the given color
+     *
+     * This method does NOT create a scene graph node for this planet.  You
+     * must call setTextures for that.
+     *
+     * @param x The initial x-coordinate of the center
+     * @param y The initial y-coordinate of the center
+     * @param c The initial color code of the planet
+     *
+     * @return a newly allocated opponent planet at the given location with the given color.
+     */
+    static std::shared_ptr<OpponentPlanet> alloc(float x, float y, CIColor::Value c) {
+        std::shared_ptr<OpponentPlanet> result = std::make_shared<OpponentPlanet>();
+        return (result->init(x, y, c, 1) ? result : nullptr);
+    }
+    
+#pragma mark Interactions
+    /**
+     * Decreases the size of the current layer
+     */
+    void decreaseLayerSize() override;
+    
+    /**
+     * Increases the size of the current layer
+     */
+    void increaseLayerSize() override;
+    
+};
+
+#endif /* __CI_OPPONENT_PLANET_H__ */

--- a/source/CIPlanetModel.h
+++ b/source/CIPlanetModel.h
@@ -19,7 +19,7 @@
 
 
 class PlanetModel {
-private:
+protected:
     /** The layers of this planet */
     std::vector<PlanetLayer> _layers;
     
@@ -211,12 +211,12 @@ public:
     /**
      * Decreases the size of the current layer
      */
-    void decreaseLayerSize();
+    virtual void decreaseLayerSize();
     
     /**
      * Increases the size of the current layer
      */
-    void increaseLayerSize();
+    virtual void increaseLayerSize();
     
     /**
      * Stops any current progress towards locking in a layer


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Core Impact Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

This PR adds a model class for opponent planets. It is a subclass of PlanetModel, but only maintains a single layer that contains the current planet color and total planet size.

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

* Added OpponentPlanet class
* Changed PlanetModel fields to be protected instead of private
* Changed decreaseLayerSize and increaseLayerSize to be virtual functions


## Next Steps

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

@wlong123 is going to use this model class for networking messages for planet updates.

Also, I will make a separate PR soon that adds the OpponentNode class to draw this information to the screen
