### PR TITLE
Process Planet Updates

### DIFF
--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -108,6 +108,9 @@ bool GameScene::init(const std::shared_ptr<cugl::AssetManager>& assets, bool isH
     _stardustContainer->addStardust(dimen);
     _stardustContainer->addStardust(dimen);
     
+    // TODO: resize to number of players in the game and add opponent planet nodes to scene graph
+    _opponent_planets.resize(5);
+    
     addChild(scene);
     addChild(_planet->getPlanetNode());
     addChild(_stardustContainer->getStardustNode());
@@ -123,15 +126,19 @@ void GameScene::dispose() {
     if (_active) {
         removeAllChildren();
         _input.dispose();
-        _gameUpdateManager = nullptr;
-        _networkMessageManager = nullptr;
-        _allSpace = nullptr;
-        _farSpace = nullptr;
-        _nearSpace = nullptr;
-        _planet = nullptr;
-        _draggedStardust = NULL;
         _active = false;
     }
+    _assets = nullptr;
+    _gameUpdateManager = nullptr;
+    _networkMessageManager = nullptr;
+    _massHUD = nullptr;
+    _allSpace = nullptr;
+    _farSpace = nullptr;
+    _nearSpace = nullptr;
+    _stardustContainer = nullptr;
+    _planet = nullptr;
+    _draggedStardust = NULL;
+    _opponent_planets.clear();
 }
 
 
@@ -146,6 +153,7 @@ void GameScene::reset() {
     _gameUpdateManager->dispose();
     _networkMessageManager->dispose();
     removeAllChildren();
+    _opponent_planets.clear();
     _active = false;
 }
 
@@ -209,7 +217,7 @@ void GameScene::update(float timestep) {
         _gameUpdateManager->sendUpdate(_planet, _stardustContainer, dimen);
         _networkMessageManager->receiveMessages();
         _networkMessageManager->sendMessages();
-        _gameUpdateManager->processGameUpdate(_stardustContainer, dimen);
+        _gameUpdateManager->processGameUpdate(_stardustContainer, _opponent_planets, dimen);
     }
 }
 

--- a/source/CIGameScene.h
+++ b/source/CIGameScene.h
@@ -24,6 +24,7 @@
 #include "CIStardustQueue.h"
 #include "CIGameUpdateManager.h"
 #include "CINetworkMessageManager.h"
+#include "CIOpponentPlanet.h"
 
 /**
  * This class is the primary gameplay constroller for the demo.
@@ -62,6 +63,8 @@ protected:
     std::shared_ptr<PlanetModel>  _planet;
     /** Pointer to the model of the stardust that is currently being dragged */
     StardustModel*  _draggedStardust;
+    /** Vector of opponent planets */
+    std::vector<std::shared_ptr<OpponentPlanet>> _opponent_planets;
     
     /** Countdown to reset the game after winning/losing */
     float _countdown;

--- a/source/CIGameUpdateManager.cpp
+++ b/source/CIGameUpdateManager.cpp
@@ -115,7 +115,7 @@ void GameUpdateManager::sendUpdate(const std::shared_ptr<PlanetModel> planet, co
  * @param stardustQueue     A reference to the player's stardust queue
  * @param bounds                    The bounds of the screen
  */
-void GameUpdateManager::processGameUpdate(std::shared_ptr<StardustQueue> stardustQueue, cugl::Size bounds) {
+void GameUpdateManager::processGameUpdate(std::shared_ptr<StardustQueue> stardustQueue, std::vector<std::shared_ptr<OpponentPlanet>> opponentPlanets, cugl::Size bounds) {
     if (_game_updates_to_process.empty() || getPlayerId() < 0) {
         return;
     }
@@ -189,9 +189,21 @@ void GameUpdateManager::processGameUpdate(std::shared_ptr<StardustQueue> stardus
                 stardustQueue->addStardust(stardust);
             }
         }
+        
+        std::shared_ptr<OpponentPlanet> planet = std::static_pointer_cast<OpponentPlanet>(gameUpdate->getPlanet());
+        if (planet == nullptr) {
+            break;
+        }
+        
+        int playerId = gameUpdate->getPlayerId();
+        if (opponentPlanets[playerId] == nullptr) {
+            opponentPlanets[playerId] = planet;
+        } else {
+            opponentPlanets[playerId]->setLayerSize(planet->getMass());
+            opponentPlanets[playerId]->setColor(planet->getColor());
+        }
+        
     }
-    
-    // TODO: update other player's planet displays
     
     _game_updates_to_process.clear();
 }

--- a/source/CIGameUpdateManager.cpp
+++ b/source/CIGameUpdateManager.cpp
@@ -46,6 +46,7 @@ void GameUpdateManager::dispose() {
 bool GameUpdateManager::init() {
     _game_updates_to_process.resize(MAX_PENDING_UPDATES);
     _prev_planet_mass = 0;
+    _player_id = -1;
     return true;
 }
 

--- a/source/CIGameUpdateManager.cpp
+++ b/source/CIGameUpdateManager.cpp
@@ -199,7 +199,7 @@ void GameUpdateManager::processGameUpdate(std::shared_ptr<StardustQueue> stardus
         if (opponentPlanets[playerId] == nullptr) {
             opponentPlanets[playerId] = planet;
         } else {
-            opponentPlanets[playerId]->setLayerSize(planet->getMass());
+            opponentPlanets[playerId]->setMass(planet->getMass());
             opponentPlanets[playerId]->setColor(planet->getColor());
         }
         

--- a/source/CIGameUpdateManager.h
+++ b/source/CIGameUpdateManager.h
@@ -19,6 +19,7 @@
 #include "CIGameUpdate.h"
 #include "CIPlanetModel.h"
 #include "CIStardustQueue.h"
+#include "CIOpponentPlanet.h"
 
 class GameUpdateManager {
 private:
@@ -129,9 +130,10 @@ public:
      * Processes current game updates from other players if there are any.
      *
      * @param stardustQueue     A reference to the player's stardust queue
+     * @param opponentPlanets A vector containing the planets of the other players
      * @param bounds                    The bounds of the screen
      */
-    void processGameUpdate(std::shared_ptr<StardustQueue> stardustQueue, cugl::Size bounds);
+    void processGameUpdate(std::shared_ptr<StardustQueue> stardustQueue, std::vector<std::shared_ptr<OpponentPlanet>> opponentPlanets, cugl::Size bounds);
 };
 
 #endif /* __CI_GAME_UPDATE_MANAGER_H__ */

--- a/source/CINetworkMessageManager.cpp
+++ b/source/CINetworkMessageManager.cpp
@@ -132,17 +132,16 @@ void NetworkMessageManager::receiveMessages() {
             else if (message_type == NetworkUtils::MessageType::PlanetUpdate) {
                 int srcPlayer = NetworkUtils::decodeInt(recv[4], recv[5], recv[6], recv[7]);
                 int planetColor = NetworkUtils::decodeInt(recv[8], recv[9], recv[10], recv[11]);
-                float planetSize = NetworkUtils::decodeInt(recv[12], recv[13], recv[14], recv[15]);
-                int timestamp = NetworkUtils::decodeFloat(recv[16], recv[17], recv[18], recv[19]);
+                float planetSize = NetworkUtils::decodeFloat(recv[12], recv[13], recv[14], recv[15]);
+                int timestamp = NetworkUtils::decodeInt(recv[16], recv[17], recv[18], recv[19]);
                 
                 CULog("RCVD PU> SRC[%i], CLR[%i], SIZE[%f]", srcPlayer, planetColor, planetSize);
 
                 std::shared_ptr<OpponentPlanet> planet = OpponentPlanet::alloc(0, 0, static_cast<CIColor::Value>(planetColor));
-                planet->setLayerSize(planetSize);
+                planet->setMass(planetSize);
                 std::map<int, std::vector<std::shared_ptr<StardustModel>>> map = {};
                 std::shared_ptr<GameUpdate> gameUpdate = GameUpdate::alloc(_conn->getRoomID(), srcPlayer, map, planet, timestamp);
                 _gameUpdateManager->addGameUpdate(gameUpdate);
-                
             }
             else {
                 CULog("WRONG MESSAGE TYPE");

--- a/source/CIOpponentPlanet.cpp
+++ b/source/CIOpponentPlanet.cpp
@@ -30,10 +30,10 @@ void OpponentPlanet::increaseLayerSize() {
 }
 
 /**
- * Sets the size of the current layer
+ * Sets the mass of the planet
  *
- * @param size The new size of this planet
+ * @param mass The new mass of this planet
  */
-void OpponentPlanet::setLayerSize(int size) {
-    _layers[_numLayers-1].layerSize = size;
+void OpponentPlanet::setMass(float mass) {
+    _mass = mass;
 }

--- a/source/CIOpponentPlanet.h
+++ b/source/CIOpponentPlanet.h
@@ -48,11 +48,11 @@ public:
     void increaseLayerSize() override;
     
     /**
-     * Sets the size of the current layer
+     * Sets the mass of the planet
      *
-     * @param size The new size of this planet
+     * @param mass The new mass of this planet
      */
-    void setLayerSize(int size);
+    void setMass(float mass);
     
 };
 


### PR DESCRIPTION
## Overview

Added code to process opponent planet updates
Also fixed some bugs in the current networking code
Also updated the game scene dispose method


## Changes Made

- created vector of opponent planets that gets updated in process game updates
- fixed networking code so message type is marshalled correctly and playerId is initialized to -1


## Next Steps (delete if not applicable)

Opponent planet node to be done by @steiner26 

