### PR TITLE
player now rewarded with a stardust for hitting another player

### DIFF
--- a/source/CICollisionController.cpp
+++ b/source/CICollisionController.cpp
@@ -63,6 +63,11 @@ void collisions::checkForCollision(const std::shared_ptr<PlanetModel>& planet, c
                 // We remove a layer due to different colored stardust
                 else {
                     planet->decreaseLayerSize();
+                    
+                    // another player has hit this planet with a stardust they sent
+                    if (stardust->getPreviousOwner() != -1) {
+                        queue->addToSendQueue(stardust);
+                    }
                 }
 
                 // Destroy the stardust

--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -201,7 +201,7 @@ void GameScene::update(float timestep) {
         _gameUpdateManager->sendUpdate(_planet, _stardustContainer, dimen);
         _networkMessageManager->receiveMessages();
         _networkMessageManager->sendMessages();
-        _gameUpdateManager->processGameUpdate(_stardustContainer, _opponent_planets, dimen);
+        _gameUpdateManager->processGameUpdate(_stardustContainer, _planet, _opponent_planets, dimen);
     }
 }
 

--- a/source/CIGameUpdateManager.h
+++ b/source/CIGameUpdateManager.h
@@ -130,10 +130,11 @@ public:
      * Processes current game updates from other players if there are any.
      *
      * @param stardustQueue     A reference to the player's stardust queue
+     * @param planet                    A reference to the player's planet
      * @param opponentPlanets A vector containing the planets of the other players
      * @param bounds                    The bounds of the screen
      */
-    void processGameUpdate(std::shared_ptr<StardustQueue> stardustQueue, std::vector<std::shared_ptr<OpponentPlanet>> opponentPlanets, cugl::Size bounds);
+    void processGameUpdate(std::shared_ptr<StardustQueue> stardustQueue, std::shared_ptr<PlanetModel> planet, std::vector<std::shared_ptr<OpponentPlanet>> opponentPlanets, cugl::Size bounds);
 };
 
 #endif /* __CI_GAME_UPDATE_MANAGER_H__ */

--- a/source/CINetworkUtils.h
+++ b/source/CINetworkUtils.h
@@ -31,7 +31,8 @@ public:
         StardustSent = 2,
         PlanetUpdate = 3,
         AttemptToWin = 4,
-        WonGame = 5
+        WonGame = 5,
+        StardustHit = 6
     };
     
     /**


### PR DESCRIPTION
## Overview

Players now receive one stardust of their planets current color (or a random color if their planet is grey) when they hit another player with one of their stardust

## Changes Made

- Added StardustHit message
- Stardust sent from other players that hit a planet now go to the send queue


## Next Steps (delete if not applicable)

Discuss other ways to reward players for hitting other players

