### PR TITLE
Layers no longer gradually increase in size and do not overlap

### DIFF
--- a/source/CIPlanetModel.cpp
+++ b/source/CIPlanetModel.cpp
@@ -12,7 +12,7 @@
 #include "CIPlanetNode.h"
 #include "CIColor.h"
 
-#define PLANET_RADIUS_DELTA             2
+#define LAYER_RADIUS_MULTIPLIER       1.9
 #define INITIAL_PLANET_RADIUS          32
 #define PLANET_MASS_DELTA              10
 #define INITIAL_PLANET_MASS            25
@@ -93,9 +93,7 @@ void PlanetModel::decreaseLayerSize() {
         if (currentLayer->layerSize == 0) {
             currentLayer->layerColor = CIColor::getNoneColor();
         }
-        _radius -= PLANET_RADIUS_DELTA;
         _mass -= PLANET_MASS_DELTA;
-        _planetNode->setRadius(_radius);
         _planetNode->setLayers(&_layers);
     }
 }
@@ -105,10 +103,8 @@ void PlanetModel::decreaseLayerSize() {
  */
 void PlanetModel::increaseLayerSize() {
     _layers[_numLayers-1].layerSize++;
-    _radius += PLANET_RADIUS_DELTA;
     _mass += PLANET_MASS_DELTA;
 
-    _planetNode->setRadius(_radius);
     _planetNode->setLayers(&_layers);
 }
 
@@ -140,7 +136,9 @@ bool PlanetModel::lockInLayer(float timestep) {
     _layerLockinTotal += LAYER_LOCKIN_TOTAL_INCREASE;
     _layers[_numLayers-1] = getNewLayer();
     _lockInProgress = 0;
+    _radius *= LAYER_RADIUS_MULTIPLIER;
     _planetNode->setLayers(&_layers);
+    _planetNode->setRadius(_radius);
     return true;
 }
 

--- a/source/CIPlanetModel.cpp
+++ b/source/CIPlanetModel.cpp
@@ -12,8 +12,9 @@
 #include "CIPlanetNode.h"
 #include "CIColor.h"
 
-#define LAYER_RADIUS_MULTIPLIER       1.9
+#define PLANET_RADIUS_DELTA           1.5
 #define INITIAL_PLANET_RADIUS          32
+#define LAYER_RADIUS_MULTIPLIER      1.85
 #define PLANET_MASS_DELTA              10
 #define INITIAL_PLANET_MASS            25
 #define INIT_LAYER_LOCKIN_TOTAL         5
@@ -89,7 +90,9 @@ bool PlanetModel::init(float x, float y, CIColor::Value c, int maxLayers) {
 void PlanetModel::decreaseLayerSize() {
     PlanetLayer* currentLayer = &_layers[_numLayers-1];
     if (currentLayer->layerSize > 0) {
+        _radius -= PLANET_RADIUS_DELTA;
         currentLayer->layerSize--;
+        _planetNode->setRadius(_radius);
         if (currentLayer->layerSize == 0) {
             currentLayer->layerColor = CIColor::getNoneColor();
         }
@@ -103,8 +106,10 @@ void PlanetModel::decreaseLayerSize() {
  */
 void PlanetModel::increaseLayerSize() {
     _layers[_numLayers-1].layerSize++;
+    _radius += PLANET_RADIUS_DELTA;
     _mass += PLANET_MASS_DELTA;
 
+    _planetNode->setRadius(_radius);
     _planetNode->setLayers(&_layers);
 }
 

--- a/source/CIPlanetNode.cpp
+++ b/source/CIPlanetNode.cpp
@@ -13,7 +13,6 @@
 #include "CIPlanetNode.h"
 #include <cugl/cugl.h>
 
-#define LOCK_IN_SCALE_DOWN  .75
 #define SPF .033 //seconds per frame
 
 void PlanetNode::draw(const std::shared_ptr<cugl::SpriteBatch>& batch,
@@ -58,17 +57,6 @@ void PlanetNode::setLayers(std::vector<PlanetLayer>* layers) {
     LayerNode* node = &_layerNodes[ii];
     if (layers->at(ii).isActive) {
       if (node->innerRing == nullptr) {
-        if (ii > 0) {
-          // decrease size of locked in layer slightly
-          if (ii == 1) {
-            _coreScale *= .8;
-            setScale(_coreScale);
-          }
-          LayerNode* prev = &_layerNodes[ii-1];
-          prev->innerRing->setScale(_layerScale*LOCK_IN_SCALE_DOWN/_coreScale);
-          prev->outerRing->setScale(_layerScale*LOCK_IN_SCALE_DOWN/_coreScale);
-        }
-        
         node->innerRing = cugl::scene2::AnimationNode::alloc(_ringTexture, INNER_RING_ROWS, INNER_RING_COLS);
         node->outerRing = cugl::scene2::PolygonNode::allocWithTexture(_unlockedTexture);
         


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Core Impact Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Very small change so layers do not grow as dots go into them, and instead the radius of the planet only changes when a new layer is added. The mass still increases the same as before

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

* Planet radius only increases when a layer is locked in
* Layers no longer decrease in size slightly when locked in

## Screenshots

<!-- If you are making any changes to UI, you should use this section. -->

<details>

  <summary>Example planet with 3 layers</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
  
<img width="1025" alt="Screen Shot 2021-04-04 at 7 37 20 PM" src="https://user-images.githubusercontent.com/40394622/113525129-2e988780-9581-11eb-8ab5-3b6274005fc4.png">


</details>