### PR TITLE
Make it so the host's progress bar appears on other players' screens

### DIFF
--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -206,10 +206,10 @@ void GameScene::update(float timestep) {
         _gameUpdateManager->processGameUpdate(_stardustContainer, _planet, _opponent_planets, dimen);
         for (int ii = 0; ii < _opponent_planets.size() ; ii++) {
             std::shared_ptr<OpponentPlanet> opponent = _opponent_planets[ii];
-            if (opponent != nullptr && getChildByTag(ii) == nullptr) {
+            if (opponent != nullptr && getChildByName(to_string(ii)) == nullptr) {
                 opponent->setTextures(_assets->get<Texture>("opponentProgress"), dimen);
                 //TODO: call opponent->setName with name and font
-                addChildWithTag(opponent->getOpponentNode(), ii);
+                addChildWithName(opponent->getOpponentNode(), to_string(ii));
             }
         }
     }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Core Impact Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Quick bugfix to make the host's progress bar appear on other players' screens. I was using tags to add OpponentNodes and check if they had been added, and apparently there is a node with tag 0 by default. I switched this code to use names instead of tags to avoid this conflict

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

Changed adding OpponentNodes to use names instead of tags.