### PR TITLE
Change opponent corners to always go in the same order

### DIFF
--- a/source/CINetworkUtils.cpp
+++ b/source/CINetworkUtils.cpp
@@ -67,12 +67,13 @@ void NetworkUtils::encodeInt(int x, std::vector<uint8_t>& out) {
  * Gets the stardust location given our player id and the player id of the opponent.
  */
 CILocation::Value NetworkUtils::getStardustLocation(int playerID, int opponentPlayerID) {
-    return CILocation::Value((opponentPlayerID - playerID + 5) % 5);
+    int location = (opponentPlayerID < playerID ? opponentPlayerID + 1 : opponentPlayerID);
+    return CILocation::Value(location);
 }
 
 /**
  * Returns an opponents player id given this player's id and a location
  */
 int NetworkUtils::getOpponentPlayerID(int playerID, CILocation::Value location) {
-    return (playerID + location) % 5;
+    return (location <= playerID ? location - 1 : location);
 }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Core Impact Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

This PR would make it so opponent corners are always assigned in the following order, no matter which player you are:
* Top Left
* Top Right
* Bottom Left
* Bottom Right

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

Changed getStardustLocation and getStardustLocation to use the new ordering system - the order is now the same as the CILocation::Value enum