### PR TITLE
Will/layer lock in rewards

### DIFF
--- a/source/CICollisionController.cpp
+++ b/source/CICollisionController.cpp
@@ -53,13 +53,8 @@ void collisions::checkForCollision(const std::shared_ptr<PlanetModel>& planet, c
 
             // If this normal is too small, there was a collision
             if (distance < impactDistance) {
-                if (stardust->getStardustType() != StardustModel::Type::NORMAL) {
-                    // special stardust dragged into planet
-                    queue->addToSendQueue(stardust);
-                    queue->addToPowerupQueue(stardust);
-                }
                 // We add a layer due to own colored stardust
-                else if (planet->getColor() == CIColor::getNoneColor()) {
+                if (planet->getColor() == CIColor::getNoneColor()) {
                     planet->setColor(stardust->getColor());
                     planet->increaseLayerSize();
                 }

--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -188,7 +188,12 @@ void GameScene::update(float timestep) {
     updateDraggedStardust();
     
     if (collisions::checkForCollision(_planet, _input.getPosition())) {
-        _planet->lockInLayer(timestep);
+        CIColor::Value planetColor = _planet->getColor();
+        if (_planet->lockInLayer(timestep)) {
+            // Layer Locked In
+            CULog("LAYER LOCKED IN");
+            _stardustContainer->addToPowerupQueue(planetColor, true);
+        }
     } else if (_planet->isLockingIn()) {
         _planet->stopLockIn();
     }
@@ -274,7 +279,7 @@ void GameScene::addStardust(const Size bounds) {
     int massCorrection = avgMass - _planet->getMass();
     
     /** Pity mechanism: The longer you haven't seen a certain color, the more likely it will be to spawn that color */
-    CIColor::Value c = CIColor::getNoneColor();
+    CIColor::Value c = CIColor::getRandomColor();
     int probSum = 0, colorCount = 6;
     // Sums up the total probability space of the stardust colors, augmented by a mass correction
     probSum = accumulate(_stardustProb, _stardustProb + colorCount, probSum) + massCorrection;
@@ -290,7 +295,7 @@ void GameScene::addStardust(const Size bounds) {
             _stardustProb[i] += 10;
         }
     }
-    
+
     _stardustContainer->addStardust(c, bounds);
 }
 
@@ -315,6 +320,13 @@ void GameScene::processSpecialStardust(const cugl::Size bounds, const std::share
                 stardustQueue->addStardust(CIColor::getRandomColor(), bounds);
                 stardustQueue->addStardust(CIColor::getRandomColor(), bounds);
                 break;
+            case StardustModel::Type::SHOOTING_STAR:
+                CULog("SHOOTING STAR");
+                stardustQueue->addShootingStardust(stardust->getColor(), bounds);
+                stardustQueue->addShootingStardust(stardust->getColor(), bounds);
+            case StardustModel::Type::GRAYSCALE:
+                CULog("GRAYSCALE");
+                stardustQueue->getStardustNode()->applyGreyScale();
             default:
                 break;
         }

--- a/source/CIGameUpdateManager.cpp
+++ b/source/CIGameUpdateManager.cpp
@@ -145,19 +145,13 @@ void GameUpdateManager::processGameUpdate(std::shared_ptr<StardustQueue> stardus
                 // this player hit another player with a stardust
                 if (stardust->getColor() == CIColor::getNoneColor()) {
                     CIColor::Value c = planet->getColor() == CIColor::getNoneColor() ? CIColor::getRandomColor() : planet->getColor();
-                    if (rand() % 10 == 0) {
-                        // meteor shower
-                        stardustQueue->addStardust(c, bounds, StardustModel::Type::METEOR);
-                        CULog("Received Meteor Powerup!");
-                        break;
-                    } else {
-                        // add 3 stardust, one is guaranteed to be a helpful color, other 2 are random
-                        stardustQueue->addStardust(c, bounds);
-                        stardustQueue->addStardust(CIColor::getRandomColor(), bounds);
-                        stardustQueue->addStardust(CIColor::getRandomColor(), bounds);
-                        CULog("Return Blast");
-                        break;
-                    }
+
+                    // add 3 stardust, one is guaranteed to be a helpful color, other 2 are random
+                    stardustQueue->addStardust(c, bounds);
+                    stardustQueue->addStardust(CIColor::getRandomColor(), bounds);
+                    stardustQueue->addStardust(CIColor::getRandomColor(), bounds);
+                    CULog("Return Blast");
+                    break;
                 }
                 
                 CULog("New stardust from player %i", gameUpdate->getPlayerId());

--- a/source/CINetworkMessageManager.cpp
+++ b/source/CINetworkMessageManager.cpp
@@ -79,7 +79,7 @@ void NetworkMessageManager::sendMessages() {
                data.clear();
                CULog("SENT Powerup> SRC[%i], POWERUP[%i], CLR[%i], TS[%i]", playerId, powerup, stardustColor, _timestamp);
             }
-            else if (val[jj]->getStardustLocation() == StardustModel::Location::ON_SCREEN) {
+            else if (val[jj]->getStardustLocation() == CILocation::Value::ON_SCREEN) {
                 NetworkUtils::encodeInt(NetworkUtils::MessageType::StardustHit, data);
                 NetworkUtils::encodeInt(playerId, data);
                 NetworkUtils::encodeInt(dstPlayerId, data);

--- a/source/CIStardustModel.h
+++ b/source/CIStardustModel.h
@@ -16,22 +16,14 @@
 class StardustModel {
 public:
     /**
-     * Enum representing where the stardust is. Top left, top right, bottom left, and bottom right all represent off screen locations.
-     */
-    enum Location {
-        ON_SCREEN = 0,
-        TOP_LEFT = 1,
-        TOP_RIGHT = 2,
-        BOTTOM_LEFT = 3,
-        BOTTOM_RIGHT = 4,
-    };
-    
-    /**
      * Enum representing the types of stardust.
      */
     enum Type {
         NORMAL = 0,
         METEOR = 1,
+        SHOOTING_STAR = 2,
+        GRAYSCALE = 3,
+        FOG = 4,
     };
 private:
     /** Color code of this stardust */

--- a/source/CIStardustNode.cpp
+++ b/source/CIStardustNode.cpp
@@ -24,6 +24,7 @@ void StardustNode::dispose() {
     _qtail = NULL;
     _qsize = NULL;
     _timeElapsed = 0;
+    _grayScaleTime = 0;
     _texture = nullptr;
 }
 

--- a/source/CIStardustNode.cpp
+++ b/source/CIStardustNode.cpp
@@ -12,6 +12,7 @@
 #include "CIColor.h"
 
 #define SPF .1 //seconds per frame
+#define GREYSCALE_TIME 5 // number of seconds for greyscale power up
 
 /**
  * Disposes the Stardust node, releasing all resources.
@@ -52,22 +53,29 @@ void StardustNode::draw(const std::shared_ptr<cugl::SpriteBatch>& batch,
                                         _queue->at(idx).getPosition().y, 0);
             stardustTransform.multiply(transform);
             
-            // Handle stardust color 
-            const cugl::Color4f stardustColor = CIColor::getColor4(_queue->at(idx).getColor());
-            switch (_queue->at(idx).getStardustType()) {
-                case StardustModel::Type::METEOR:
-                    AnimationNode::draw(batch, stardustTransform, CIColor::getColor4(CIColor::Value::grey));
-                    break;
-                default:
-                    AnimationNode::draw(batch, stardustTransform, stardustColor);
-                    cugl::Color4 tailColor = cugl::Color4(stardustColor);
-                    tailColor.a = 125;
-                    stardustTransform.translate(-_queue->at(idx).getVelocity().x * 2, -_queue->at(idx).getVelocity().y * 2, 0);
-                    AnimationNode::draw(batch, stardustTransform, tailColor);
+            // draw stardust
+            cugl::Color4f stardustColor = CIColor::getColor4(_queue->at(idx).getColor());
+            if (_grayScaleTime > 0) {
+                stardustColor = cugl::Color4::GRAY;
             }
+            
+            AnimationNode::draw(batch, stardustTransform, stardustColor);
+            
+            // draw tail
+            cugl::Color4 tailColor = cugl::Color4(stardustColor);
+            tailColor.a = 125;
+            stardustTransform.translate(-_queue->at(idx).getVelocity().x * 2, -_queue->at(idx).getVelocity().y * 2, 0);
+            AnimationNode::draw(batch, stardustTransform, tailColor);
         }
     }
     batch->setBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+}
+
+/**
+ * Applies a greyscale to all stardust for a period of time.
+ */
+void StardustNode::applyGreyScale() {
+    _grayScaleTime = GREYSCALE_TIME;
 }
 
 /**
@@ -81,5 +89,9 @@ void StardustNode::update(float timestep) {
       unsigned int coreFrame = getFrame();
       coreFrame = (coreFrame == STARDUST_END) ? STARDUST_START : coreFrame + 1;
       setFrame(coreFrame);
+    }
+    
+    if (_grayScaleTime > 0) {
+        _grayScaleTime -= timestep;
     }
 }

--- a/source/CIStardustNode.h
+++ b/source/CIStardustNode.h
@@ -35,6 +35,9 @@ private:
 
     /** The amount of time since last animation frame change */
     float _timeElapsed;
+    
+    /** The amount of time the stardust should be drawn gray. This will only be set if a power up has been used. */
+    float _grayScaleTime;
 
 public:
     /** 
@@ -87,7 +90,8 @@ public:
         _qtail = tail;
         _qsize = size;
 
-        _timeElapsed = 0;        
+        _timeElapsed = 0;
+        _grayScaleTime = 0;
         return true;
     }
     
@@ -108,6 +112,11 @@ public:
     const std::shared_ptr<cugl::Texture> getTexture() const {
         return _texture;
     }
+    
+    /**
+     * Applies a greyscale to all stardust for a period of time.
+     */
+    void applyGreyScale();
     
     /**
      * Updates the frame of the stardust animation

--- a/source/CIStardustQueue.cpp
+++ b/source/CIStardustQueue.cpp
@@ -81,6 +81,26 @@ void StardustQueue::addStardust(CIColor::Value c, const Size bounds, StardustMod
 }
 
 /**
+ * Adds a stardust that will move fast and be aimed directly at the core.
+ * This is the result of the shooting star powerup.
+ *
+ * @param c the color of the stardust to spawn
+ * @param bounds the bounds of the game screen
+ */
+void StardustQueue::addShootingStardust(CIColor::Value c, const cugl::Size bounds) {
+    int posX = ((rand()%2==0) ? bounds.width + 5 : -5) + (rand() % 20 - 10);
+    int posY = ((rand()%2==0) ? bounds.height + 5 : -5) + (rand() % 20 - 10);
+    Vec2 pos = Vec2(posX, posY);
+    Vec2 dir = Vec2(bounds.width/2, bounds.height/2) - pos;
+    dir.normalize();
+    dir.x *= 10;
+    dir.y *= 10;
+
+    std::shared_ptr<StardustModel> stardust = StardustModel::alloc(pos, dir, c);
+    addStardust(stardust);
+}
+
+/**
  * Adds a stardust to the active queue given a pointer to the stardust
  *
  * @param stardust the stardust to add to the queue
@@ -131,6 +151,36 @@ void StardustQueue::addToSendQueue(StardustModel* stardust) {
  */
 void StardustQueue::addToPowerupQueue(StardustModel* stardust) {
     _stardust_powerups.push_back(std::make_shared<StardustModel>(*stardust));
+}
+
+/**
+ * Adds a powerup to the powerup queue.
+ *
+ * @param color the color of layer that was just locked in
+ * @param addToSendQueue whether to add the stardust to the send queue
+ */
+void StardustQueue::addToPowerupQueue(CIColor::Value color, bool addToSendQueue) {
+    std::shared_ptr<StardustModel> stardust = StardustModel::alloc(cugl::Vec2(), cugl::Vec2(), CIColor::getRandomColor());
+    switch (color) {
+        case CIColor::Value::red:
+            stardust->setStardustType(StardustModel::Type::METEOR);
+            _stardust_powerups.push_back(stardust);
+            break;
+        case CIColor::Value::yellow:
+            stardust->setStardustType(StardustModel::Type::SHOOTING_STAR);
+            _stardust_powerups.push_back(stardust);
+            break;
+        case CIColor::Value::purple:
+            stardust->setStardustType(StardustModel::Type::GRAYSCALE);
+            break;
+        default:
+            break;
+    }
+    
+    if (addToSendQueue && stardust->getStardustType() != StardustModel::Type::NORMAL) {
+        _stardust_to_send.push_back(stardust);
+    }
+    
 }
 
 /**

--- a/source/CIStardustQueue.h
+++ b/source/CIStardustQueue.h
@@ -115,6 +115,15 @@ public:
     void addStardust(CIColor::Value c, const cugl::Size bounds, StardustModel::Type type = StardustModel::Type::NORMAL);
     
     /**
+     * Adds a stardust that will move fast and be aimed directly at the core.
+     * This is the result of the shooting star powerup.
+     *
+     * @param c the color of the stardust to spawn
+     * @param bounds the bounds of the game screen
+     */
+    void addShootingStardust(CIColor::Value c, const cugl::Size bounds);
+    
+    /**
      * Adds a stardust to the active queue given a pointer to the stardust
      *
      * @param stardust the stardust to add to the queue
@@ -191,13 +200,20 @@ public:
         _stardust_to_send.clear();
     }
     
-
     /**
      * Adds a stardust to the powerup queue.
      *
      * @param stardust the stardust to add to the powerup queue
      */
     void addToPowerupQueue(StardustModel* stardust);
+    
+    /**
+     * Adds a powerup to the powerup queue.
+     *
+     * @param color the color of layer that was just locked in
+     * @param addToSendQueue whether to add the stardust to the send queue
+     */
+    void addToPowerupQueue(CIColor::Value color, bool addToSendQueue);
     
     /**
      * Returns the powerup queue


### PR DESCRIPTION
## Overview

Added lock in power ups for meteor, shooting star, and grayscale.



## Changes Made

- Removed logic for adding special stardust to the screen (this was done in the meteor reward for hitting another player)
- Added logic for sending and processing powerups using the powerup queue
- patched minor bug in stardust spawning where a gray stardust occassionally occurred


## Next Steps (delete if not applicable)

Still need to add in fog powerup. I think we might want a fog asset
Probably going to add on screen indicator for a lock in occurring