### PR TITLE
added basic win screen

### DIFF
--- a/assets/json/assets.json
+++ b/assets/json/assets.json
@@ -25,6 +25,9 @@
         "file":   "textures/fog.png"
     }
   },
+  "widgets": {
+    "backbutton": "widgets/backbutton.json"
+  },
   "fonts": {
     "saira32": {
       "file": "fonts/SairaSemicondensed.ttf",
@@ -82,6 +85,68 @@
             "x_offset": 10,
             "y_offset": 10,
             "absolute": true
+          }
+        },
+        "win": {
+          "type": "Node",
+          "format": {
+            "type": "Anchored"
+          },
+          "children": {
+            "gameOutcomeLabel": {
+              "comment": "The text label showing the outcome of the game",
+              "type": "Label",
+              "data": {
+                "font": "saira32",
+                "text": "",
+                "foreground": [255, 255, 255, 255],
+                "background": [0, 0, 0, 0],
+                "size": [200, 80],
+                "anchor": [0.5, 0.5],
+                "halign": "center",
+                "valign": "middle",
+                "visible": false
+              },
+              "layout": {
+                "x_anchor": "center",
+                "y_anchor": "middle",
+                "y_offset": 0.4
+              }
+            },
+            "backToHomeButton": {
+              "comment": "The button that brings a player back to the home screen",
+              "type": "Widget",
+              "data": {
+                  "key": "backbutton",
+                  "variables" : {
+                      "size"  : [200,200],
+                      "text"  : "Back to Home"
+                  }
+              },
+              "layout": {
+                "x_anchor": "center",
+                "y_anchor": "middle",
+                "x_offset": -0.2,
+                "y_offset": 0.2
+              }
+            },
+            "newGameButton": {
+              "comment": "The button that brings a player to the new game screen",
+              "type": "Widget",
+              "data": {
+                "key": "backbutton",
+                "variables" : {
+                  "size"  : [200,200],
+                  "text"  : "New Game"
+                }
+              },
+              "layout": {
+                "x_anchor": "center",
+                "y_anchor": "middle",
+                "x_offset": 0.2,
+                "y_offset": 0.2
+              }
+            }
           }
         }
       }

--- a/build-apple/CoreImpact.xcodeproj/project.pbxproj
+++ b/build-apple/CoreImpact.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		3D94040725FFC52400043357 /* CIGameUpdateManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D94040625FFC52400043357 /* CIGameUpdateManager.cpp */; };
 		3D94040825FFC52400043357 /* CIGameUpdateManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D94040625FFC52400043357 /* CIGameUpdateManager.cpp */; };
 		3D94040925FFC52400043357 /* CIGameUpdateManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D94040625FFC52400043357 /* CIGameUpdateManager.cpp */; };
+		3DA35B1C262B56A500A578DF /* CIWinScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DA35B1B262B56A500A578DF /* CIWinScene.cpp */; };
+		3DA35B1D262B56A500A578DF /* CIWinScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DA35B1B262B56A500A578DF /* CIWinScene.cpp */; };
+		3DA35B1E262B56A500A578DF /* CIWinScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DA35B1B262B56A500A578DF /* CIWinScene.cpp */; };
 		3DCE833825FDC3B8007EBA2D /* CIGameUpdate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DCE833725FDC3B8007EBA2D /* CIGameUpdate.cpp */; };
 		3DCE833925FDC3B8007EBA2D /* CIGameUpdate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DCE833725FDC3B8007EBA2D /* CIGameUpdate.cpp */; };
 		3DCE833A25FDC3B8007EBA2D /* CIGameUpdate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DCE833725FDC3B8007EBA2D /* CIGameUpdate.cpp */; };
@@ -178,6 +181,8 @@
 		3D563BF725F6D5B7006641B1 /* CIPlanetNode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CIPlanetNode.cpp; sourceTree = "<group>"; };
 		3D94040225FFC50C00043357 /* CIGameUpdateManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CIGameUpdateManager.h; sourceTree = "<group>"; };
 		3D94040625FFC52400043357 /* CIGameUpdateManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CIGameUpdateManager.cpp; sourceTree = "<group>"; };
+		3DA35B17262B569400A578DF /* CIWinScene.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CIWinScene.h; sourceTree = "<group>"; };
+		3DA35B1B262B56A500A578DF /* CIWinScene.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CIWinScene.cpp; sourceTree = "<group>"; };
 		3DCE833625FDB914007EBA2D /* CIGameUpdate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CIGameUpdate.h; sourceTree = "<group>"; };
 		3DCE833725FDC3B8007EBA2D /* CIGameUpdate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CIGameUpdate.cpp; sourceTree = "<group>"; };
 		3DCF90D22605198D00B97FA1 /* CINetworkMessageManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CINetworkMessageManager.h; sourceTree = "<group>"; };
@@ -382,6 +387,8 @@
 				42B54D5A261B8C000097D816 /* CISettingsMenu.h */,
 				42B54D46261B854D0097D816 /* CITutorialMenu.cpp */,
 				42B54D42261B83F80097D816 /* CITutorialMenu.h */,
+				3DA35B17262B569400A578DF /* CIWinScene.h */,
+				3DA35B1B262B56A500A578DF /* CIWinScene.cpp */,
 			);
 			name = Scene;
 			sourceTree = "<group>";
@@ -745,6 +752,7 @@
 				3DCF91202607B5B600B97FA1 /* CINetworkUtils.cpp in Sources */,
 				EBFA52A021FA5D1300CCC2C5 /* CIGameScene.cpp in Sources */,
 				426951F2260FCE5000E675E9 /* CIMenuScene.cpp in Sources */,
+				3DA35B1E262B56A500A578DF /* CIWinScene.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -775,6 +783,7 @@
 				3DCF911F2607B5B600B97FA1 /* CINetworkUtils.cpp in Sources */,
 				EBFA529F21FA5D1300CCC2C5 /* CIGameScene.cpp in Sources */,
 				426951F1260FCE5000E675E9 /* CIMenuScene.cpp in Sources */,
+				3DA35B1D262B56A500A578DF /* CIWinScene.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -805,6 +814,7 @@
 				3DCF911E2607B5B600B97FA1 /* CINetworkUtils.cpp in Sources */,
 				EB2BE9B61D74952A002FE78B /* main.cpp in Sources */,
 				426951F0260FCE5000E675E9 /* CIMenuScene.cpp in Sources */,
+				3DA35B1C262B56A500A578DF /* CIWinScene.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -123,10 +123,7 @@ bool GameScene::init(const std::shared_ptr<cugl::AssetManager>& assets,
         _stardustProb[i] = 100;
     }
     CIColor::setNumColors(_colorCount);
-    
-    _countdown = INACTIVE_WIN_COUNTER;
-    _timeElapsed = 0;
-    
+
     addChild(scene);
     addChild(_planet->getPlanetNode());
     addChild(_stardustContainer->getStardustNode());

--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -41,9 +41,6 @@ using namespace std;
 /** Maximum number of layers in planet model */
 #define MAX_PLANET_LAYERS 3
 
-/** Starting value for the winning countdown (game was won) */
-#define START_WIN_COUNTER 2.0f
-
 
 #pragma mark -
 #pragma mark Constructors
@@ -103,6 +100,9 @@ bool GameScene::init(const std::shared_ptr<cugl::AssetManager>& assets,
     _farSpace = std::dynamic_pointer_cast<scene2::AnimationNode>(_assets->get<scene2::SceneNode>("game_field_far"));
     _nearSpace = _assets->get<scene2::SceneNode>("game_field_near");
     _massHUD  = std::dynamic_pointer_cast<scene2::Label>(_assets->get<scene2::SceneNode>("game_hud"));
+    
+    // create the win scene
+    _winScene = WinScene::alloc(assets);
 
     // Create the planet model
     _planet = PlanetModel::alloc(dimen.width / 2, dimen.height / 2, CIColor::getNoneColor(), MAX_PLANET_LAYERS, gravStrength, planetMassToWin);
@@ -131,8 +131,6 @@ bool GameScene::init(const std::shared_ptr<cugl::AssetManager>& assets,
     addChild(_planet->getPlanetNode());
     addChild(_stardustContainer->getStardustNode());
 
-    _countdown = INACTIVE_WIN_COUNTER;
-
     CULog("Game Room Id: %s Spawn Rate: %f Gravity Strength: %f Color Count: %i Game Win Cond: %i", gameId.c_str(), spawnRate, gravStrength, colorCount, planetMassToWin);
     _timeElapsed = 0;
     return true;
@@ -158,6 +156,8 @@ void GameScene::dispose() {
     _planet = nullptr;
     _draggedStardust = NULL;
     _opponent_planets.clear();
+    
+    _winScene = nullptr;
 }
 
 
@@ -182,19 +182,17 @@ void GameScene::update(float timestep) {
     
      // Handle counting down then switching to loading screen
      if (_networkMessageManager->getWinnerPlayerId() != -1) {
-         if (_countdown <= INACTIVE_WIN_COUNTER) {
+         if (!_winScene->displayActive()) {
              // handle winning. starts off win countdown
              CULog("Game won.");
-             _countdown = START_WIN_COUNTER;
-         } else if (_countdown > 0.0f) {
-             // handle win countdown
-             _countdown -= timestep;
-             return;
-         } else if (_countdown > INACTIVE_WIN_COUNTER) {
+             _winScene->setWinner(_networkMessageManager->getWinnerPlayerId(), _networkMessageManager->getPlayerId());
+             _winScene->setDisplay(true);
+         } else if (_winScene->goBackToHome()) {
              // handle resetting game
+             _winScene->setDisplay(false);
              setActive(false);
-             return;
          }
+         return;
      }
     
     _timeElapsed += timestep;

--- a/source/CIGameScene.h
+++ b/source/CIGameScene.h
@@ -25,15 +25,13 @@
 #include "CIGameUpdateManager.h"
 #include "CINetworkMessageManager.h"
 #include "CIOpponentPlanet.h"
+#include "CIWinScene.h"
 
 /** Base stardust spawn rate */
 #define BASE_SPAWN_RATE 40
 
 /** Default number of stardust color counts */
-#define DEFAULT_COLOR_COUNTS 6
-
-/** Value for the winning counter when inactive (game not won) */
-#define INACTIVE_WIN_COUNTER -10.0f
+#define DEFAULT_COLOR_COUNTS 4
 
 #define SPF .066 //seconds per frame
 #define BACKGROUND_START 0
@@ -88,11 +86,11 @@ protected:
     /** Number of stardust colors available in game */
     uint8_t _colorCount;
 
-    /** Countdown to reset the game after winning/losing */
-    float _countdown;
-    
     /** Time since last animation frame update */
     float _timeElapsed;
+    
+    /** Pointer to the win scene */
+    std::shared_ptr<WinScene> _winScene;
     
 public:
 #pragma mark -
@@ -103,7 +101,7 @@ public:
      * This constructor does not allocate any objects or start the game.
      * This allows us to use the object without a heap pointer.
      */
-    GameScene() : cugl::Scene2(), _spawnRate(BASE_SPAWN_RATE), _colorCount(DEFAULT_COLOR_COUNTS), _countdown(INACTIVE_WIN_COUNTER) {
+    GameScene() : cugl::Scene2(), _spawnRate(BASE_SPAWN_RATE), _colorCount(DEFAULT_COLOR_COUNTS) {
         for (int i = 0; i < 6; i++) {
             _stardustProb[i] = 0;
         }

--- a/source/CIMainMenu.h
+++ b/source/CIMainMenu.h
@@ -3,7 +3,7 @@
 //  CoreImpact
 //
 //  Created by Richard Yoon on 4/5/21.
-//  Copyright © 2021 Game Design Initiative at Cornell. All rights reserved.
+//  Copyright ï¿½ 2021 Game Design Initiative at Cornell. All rights reserved.
 //
 
 #ifndef __CI_MAIN_MENU_H__

--- a/source/CIMainMenu.h
+++ b/source/CIMainMenu.h
@@ -3,7 +3,7 @@
 //  CoreImpact
 //
 //  Created by Richard Yoon on 4/5/21.
-//  Copyright � 2021 Game Design Initiative at Cornell. All rights reserved.
+//  Copyright © 2021 Game Design Initiative at Cornell. All rights reserved.
 //
 
 #ifndef __CI_MAIN_MENU_H__

--- a/source/CIWinScene.cpp
+++ b/source/CIWinScene.cpp
@@ -1,0 +1,86 @@
+//
+//  CIWinScene.cpp
+//  CoreImpact
+//
+//  Class containing UI elements that get displayed after a game has ended.
+//
+//  Created by William Long on 4/17/21.
+//  Copyright © 2021 Game Design Initiative at Cornell. All rights reserved.
+//
+
+#include "CIWinScene.h"
+
+/**
+ * Disposes of all (non-static) resources allocated to this win scene.
+ */
+void WinScene::dispose() {
+    if (_backToHomeButton != nullptr && _backToHomeButton->isActive()) {
+        _backToHomeButton->deactivate();
+        _newGameButton->deactivate();
+    }
+    
+    _gameOutcomeLabel = nullptr;
+    _backToHomeButton = nullptr;
+    _newGameButton = nullptr;
+    _goBackToHome = false;
+}
+
+/**
+ * Initializes a new win scene.
+ *
+ * @param assets    The (loaded) assets for this win scene
+ *
+ * @return true if initialization was successful, false otherwise
+ */
+bool WinScene::init(const std::shared_ptr<cugl::AssetManager>& assets) {
+    _gameOutcomeLabel = std::dynamic_pointer_cast<cugl::scene2::Label>(assets->get<cugl::scene2::SceneNode>("game_win_gameOutcomeLabel"));
+    _backToHomeButton = std::dynamic_pointer_cast<cugl::scene2::Button>(assets->get<cugl::scene2::SceneNode>("game_win_backToHomeButton"));
+    _backToHomeButton->addListener([&](const std::string& name, bool down) {
+        if (!down) {
+            _goBackToHome = true;
+        }
+    });
+    
+    // TODO: change this listener
+    _newGameButton = std::dynamic_pointer_cast<cugl::scene2::Button>(assets->get<cugl::scene2::SceneNode>("game_win_newGameButton"));
+    _newGameButton->addListener([&](const std::string& name, bool down) {
+        if (!down) {
+            _goBackToHome = true;
+        }
+    });
+    _goBackToHome = false;
+    return true;
+}
+
+/**
+ * Sets the winner of the game.
+ *
+ * @param winnerPlayerId The player id of the player who won the game
+ * @param playerId               The player id of the player playing on this device
+ */
+void WinScene::setWinner(int winnerPlayerId, int playerId) {
+    if (winnerPlayerId == playerId) {
+        _gameOutcomeLabel->setText("Congratulations! You won the game!");
+    } else {
+        _gameOutcomeLabel->setText("Sorry! Player " + std::to_string(playerId) + " won the game.");
+    }
+}
+
+/**
+ * Sets whether the win scene is currently active and visible.
+ *
+ * @param onDisplay     Whether the win scene is currently active and visible
+ */
+void WinScene::setDisplay(bool onDisplay) {
+    _gameOutcomeLabel->setVisible(onDisplay);
+    _backToHomeButton->setVisible(onDisplay);
+    _newGameButton->setVisible(onDisplay);
+    
+    if (onDisplay) {
+        _backToHomeButton->activate();
+        _newGameButton->activate();
+    } else {
+        _backToHomeButton->deactivate();
+        _newGameButton->deactivate();
+    }
+}

--- a/source/CIWinScene.h
+++ b/source/CIWinScene.h
@@ -1,0 +1,111 @@
+//
+//  CIWinScene.h
+//  CoreImpact
+//
+//  Class containing UI elements that get displayed after a game has ended.
+//
+//  Created by William Long on 4/17/21.
+//  Copyright © 2021 Game Design Initiative at Cornell. All rights reserved.
+//
+
+#ifndef __CI_WIN_SCENE_H__
+#define __CI_WIN_SCENE_H__
+
+#include <cugl/cugl.h>
+
+class WinScene {
+private:
+    /** Label that displays the outcome of the game. */
+    std::shared_ptr<cugl::scene2::Label> _gameOutcomeLabel;
+    /** Button that brings a player back to the home screen. */
+    std::shared_ptr<cugl::scene2::Button> _backToHomeButton;
+    /** Button that starts a new game. */
+    std::shared_ptr<cugl::scene2::Button> _newGameButton;
+    
+    /** Flag variable to indicated whether to bring the user back to the home screen. */
+    bool _goBackToHome;
+    
+public:
+#pragma mark -
+#pragma mark Constructors
+    /**
+     * Creates a new win scene
+     *
+     * This constructor does not allocate any objects or start the game.
+     * This allows us to use the object without a heap pointer.
+     */
+    WinScene() {}
+
+    /**
+     * Disposes of all (non-static) resources allocated to this mode.
+     *
+     * This method is different from dispose() in that it ALSO shuts off any
+     * static resources, like the input controller.
+    */
+    ~WinScene() { dispose(); }
+
+    /**
+     * Disposes of all (non-static) resources allocated to this win scene.
+     */
+    void dispose();
+
+    /**
+     * Initializes a new win scene.
+     *
+     * @param assets    The (loaded) assets for this win scene
+     *
+     * @return true if initialization was successful, false otherwise
+     */
+    bool init(const std::shared_ptr<cugl::AssetManager>& assets);
+
+
+    /**
+     * Returns a newly allocated Win Scene
+     *
+     * @param assets    The (loaded) assets for this win scene
+     *
+     * @return a newly allocated main menu
+     */
+    static std::shared_ptr<WinScene> alloc(const std::shared_ptr<cugl::AssetManager>& assets) {
+        std::shared_ptr<WinScene> result = std::make_shared<WinScene>();
+        return (result->init(assets) ? result : nullptr);
+    }
+
+#pragma mark -
+#pragma mark Menu Monitoring
+    // TODO: switch this to use player names
+    /**
+     * Sets the winner of the game.
+     *
+     * @param winnerPlayerId The player id of the player who won the game
+     * @param playerId               The player id of the player playing on this device
+     */
+    void setWinner(int winnerPlayerId, int playerId);
+    
+    /**
+     * Sets whether the win scene is currently active and visible.
+     *
+     * @param onDisplay     Whether the win scene is currently active and visible
+     */
+    void setDisplay(bool onDisplay);
+    
+    /**
+     * Returns whether the win screen display is active.
+     *
+     * @return whether the win screen display is active
+     */
+    bool displayActive() {
+        return _gameOutcomeLabel->isVisible();
+    }
+    
+    /**
+     * Returns whether the user has clicked the go back to home button.
+     *
+     * @return whether the user has clicked the go back to home button
+     */
+    bool goBackToHome() {
+        return _goBackToHome;
+    }
+};
+
+#endif /* __CI_WIN_SCENE_H__ */


### PR DESCRIPTION
## Overview

Added basic win screen that brings a player back to the main menu


## Changes Made

Added win screen
Removed countdown variables from game scene
Set default color count to 4


## Next Steps (delete if not applicable)

Add animations for win scene
Right now both the buttons just bring you back to the root of the menu scene. This should probably be changed


## Screenshots (delete if not applicable)

<img width="1016" alt="Screen Shot 2021-04-17 at 4 01 07 PM" src="https://user-images.githubusercontent.com/14276502/115125529-bf665e80-9f96-11eb-8bb2-fdc43afacd2f.png">
