### PR TITLE
Spawning Improvements

### DIFF
--- a/build-android/app/build.gradle
+++ b/build-android/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "30.0.3"
     
     defaultConfig {
-        applicationId "com.elipsis.android.coreimpact"
+        applicationId "com.ellipsis.coreimpact"
         minSdkVersion 24
         targetSdkVersion 30
         versionCode 1

--- a/source/CIColor.h
+++ b/source/CIColor.h
@@ -29,9 +29,9 @@ public:
         purple,
         red,
         yellow,
+        turquoise,
         blue,
         green,
-        turquoise,
         grey,
         lightgrey,
     };

--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -114,7 +114,7 @@ bool GameScene::init(const std::shared_ptr<cugl::AssetManager>& assets,
     
     // update stardustProb to match colorCount
     for (int i = 0; i < _colorCount; i++) {
-        _stardustProb[i] = 100;
+        _stardustProb[i] = BASE_PROBABILITY_SPACE;
     }
     CIColor::setNumColors(_colorCount);
 
@@ -297,23 +297,54 @@ void GameScene::addStardust(const Size bounds) {
     
     /** Pity mechanism: The longer you haven't seen a certain color, the more likely it will be to spawn that color */
     CIColor::Value c = CIColor::getRandomColor();
-    int probSum = 0;
+    int probSum = 0, largestProb = 0;
     // Sums up the total probability space of the stardust colors, augmented by a mass correction
+    largestProb = *max_element(_stardustProb, _stardustProb + _colorCount);
+    massCorrection = min(largestProb, max(-largestProb, massCorrection));
     probSum = accumulate(_stardustProb, _stardustProb + _colorCount, probSum) + massCorrection;
     // Randomly selects a point in the probability space
     int spawnRand = rand() % max(1, probSum);
     for (int i = 0; i < _colorCount; i++) {
         spawnRand -= (CIColor::Value(i) == _planet->getColor()) ? _stardustProb[i] - massCorrection : _stardustProb[i];
+        // Primary Mechanism
         if (spawnRand <= 0){
             c = CIColor::Value(i);
-            spawnRand = probSum;
+            spawnRand = INT_MAX;
             _stardustProb[i] = max(_stardustProb[i] - BASE_SPAWN_RATE, 0);
         } else {
-            _stardustProb[i] += 10;
+            // Maintains probability state size consistency
+            _stardustProb[i] += (BASE_SPAWN_RATE / (_colorCount - 1))
+                + (((BASE_PROBABILITY_SPACE * _colorCount) - probSum) / _colorCount);
         }
     }
-
-    _stardustContainer->addStardust(c, bounds);
+    
+    while (c > _colorCount){
+        // Something has gone terribly wrong
+        CULog("深刻なエラーが発生しました");
+        c = CIColor::getRandomColor();
+    }
+    
+    /** Looparound Mechanism: Tries to make it so that players can't just send it straight back */
+    int cornerProb[] = {10,10,10,10};
+    CILocation::Value spawnCorner = CILocation::Value(0);
+    for (const std::shared_ptr<OpponentPlanet> &op : _opponent_planets){
+        if (op != nullptr){
+            if (op->getColor() == c){
+                cornerProb[op->getLocation()-1] += 60;
+            }
+        }
+    }
+    int cornerSum = 0;
+    cornerSum = accumulate(cornerProb, cornerProb + 4, cornerSum);
+    int cornerRand = rand() % cornerSum;
+    for (int i = 0; i < 4; i++) {
+        cornerRand -= cornerProb[i];
+        if (cornerRand <= 0){
+            spawnCorner = CILocation::Value(i+1);
+            break;
+        }
+    }
+    _stardustContainer->addStardust(c, bounds, spawnCorner);
 }
 
 /**

--- a/source/CIGameScene.h
+++ b/source/CIGameScene.h
@@ -30,6 +30,7 @@
 
 /** Base stardust spawn rate */
 #define BASE_SPAWN_RATE 40
+#define BASE_PROBABILITY_SPACE 100
 
 /** Default number of stardust color counts */
 #define DEFAULT_COLOR_COUNTS 4

--- a/source/CIStardustQueue.cpp
+++ b/source/CIStardustQueue.cpp
@@ -175,7 +175,7 @@ void StardustQueue::addToPowerupQueue(CIColor::Value color, bool addToSendQueue)
         case CIColor::Value::purple:
             stardust->setStardustType(StardustModel::Type::GRAYSCALE);
             break;
-        case CIColor::Value::blue:
+        case CIColor::Value::turquoise:
             stardust->setStardustType(StardustModel::Type::FOG);
             break;
         default:

--- a/source/CIStardustQueue.cpp
+++ b/source/CIStardustQueue.cpp
@@ -62,13 +62,15 @@ bool StardustQueue::init(size_t max, const std::shared_ptr<cugl::Texture>& textu
  *
  * @param c the color of the stardust to spawn
  * @param bounds the bounds of the game screen
+ * @param corner the corner to spawn in
  * @param type the type of the stardust to add (defaults to normal)
  */
-void StardustQueue::addStardust(CIColor::Value c, const Size bounds, StardustModel::Type type) {
+void StardustQueue::addStardust(CIColor::Value c, const Size bounds, const CILocation::Value corner, StardustModel::Type type) {
     // Add a new stardust at the end.
     // Already declared, so just initialize.
-    int posX = ((rand()%2==0) ? bounds.width + 20 : -20) + (rand() % 20 - 10);
-    int posY = ((rand()%2==0) ? bounds.height + 20 : -20) + (rand() % 20 - 10);
+    int spawnCorner = (corner == 0) ? rand() % 4 : corner - 1;
+    int posX = ((spawnCorner % 2 == 0) ? -20 : bounds.width + 20) + (rand() % 20 - 10);
+    int posY = ((spawnCorner / 2 == 0) ? bounds.height + 20 : -20) + (rand() % 20 - 10);
     Vec2 pos = Vec2(posX, posY);
     Vec2 dir = Vec2(bounds.width/2, bounds.height/2) - pos;
     dir.normalize();

--- a/source/CIStardustQueue.h
+++ b/source/CIStardustQueue.h
@@ -110,9 +110,10 @@ public:
      *
      * @param c the color of the stardust to spawn
      * @param bounds the bounds of the game screen
+     * @param corner the corner to spawn in
      * @param type the type of the stardust to add (defaults to normal)
      */
-    void addStardust(CIColor::Value c, const cugl::Size bounds, StardustModel::Type type = StardustModel::Type::NORMAL);
+    void addStardust(CIColor::Value c, const cugl::Size bounds, const CILocation::Value corner = CILocation::ON_SCREEN, StardustModel::Type type = StardustModel::Type::NORMAL);
     
     /**
      * Adds a stardust that will move fast and be aimed directly at the core.


### PR DESCRIPTION
## Overview

Improved Spawning Algorithm

## Changes Made

- Fixed Repeat Spawning Bug (Mass correction when the client planet is large enough inverts the probability space and always spawns the last color stardust.)
  - Added Probability Space Homeostatis
  - Failsafes Added
- Added Opponent Color Spawning (More likely to spawn color of opponent from opponent corner, causing player to choose something other than shortest distance)

## Next Steps

Possible Burst Spawning Algorithm