### PR TITLE
OpponentPlanets are now created at the start of the game

### DIFF
--- a/assets/json/assets.json
+++ b/assets/json/assets.json
@@ -29,6 +29,10 @@
     "saira32": {
       "file": "fonts/SairaSemicondensed.ttf",
       "size": 32
+    },
+    "saira20": {
+      "file": "fonts/SairaSemicondensed.ttf",
+      "size": 20
     }
   },
   "scene2s": {

--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -100,9 +100,6 @@ bool GameScene::init(const std::shared_ptr<cugl::AssetManager>& assets,
     _draggedStardust = NULL;
     _stardustContainer = StardustQueue::alloc(CONSTANTS::MAX_STARDUSTS, coreTexture);
 
-    // TODO: resize to number of players in the game and add opponent planet nodes to scene graph
-    _opponent_planets.resize(5);
-
     // Game settings
     _gameSettings = gameSettings;
     // Player settings
@@ -117,6 +114,21 @@ bool GameScene::init(const std::shared_ptr<cugl::AssetManager>& assets,
     addChild(scene);
     addChild(_planet->getPlanetNode());
     addChild(_stardustContainer->getStardustNode());
+    
+    std::vector<string> opponentNames = networkMessageManager->getOtherNames();
+    _opponentPlanets.resize((int) opponentNames.size());
+    for (int ii = 0; ii < _opponentPlanets.size(); ii++) {
+        if (opponentNames[ii] == "") {
+            continue;
+        }
+        CILocation::Value location = CILocation::Value(ii+1);
+        cugl::Vec2 pos = CILocation::getPositionOfLocation(location, dimen);
+        std::shared_ptr<OpponentPlanet> opponent = OpponentPlanet::alloc(pos.x, pos.y, CIColor::getNoneColor(), location);
+        opponent->setTextures(_assets->get<Texture>("opponentProgress"), _assets->get<Texture>("fog"), dimen);
+        opponent->setName(opponentNames[ii], assets->get<Font>("saira20"));
+        addChild(opponent->getOpponentNode());
+        _opponentPlanets[ii] = opponent;
+    }
     return true;
 }
 
@@ -139,7 +151,7 @@ void GameScene::dispose() {
     _stardustContainer = nullptr;
     _planet = nullptr;
     _draggedStardust = NULL;
-    _opponent_planets.clear();
+    _opponentPlanets.clear();
     
     _winScene = nullptr;
 }
@@ -214,18 +226,12 @@ void GameScene::update(float timestep) {
         _gameUpdateManager->setPlayerId(_networkMessageManager->getPlayerId());
     } else {
         // send and receive game updates to other players
-        _gameUpdateManager->sendUpdate(_planet, _stardustContainer, dimen);
+        _gameUpdateManager->sendUpdate(_planet, _stardustContainer);
         _networkMessageManager->receiveMessages();
         _networkMessageManager->sendMessages();
-        _gameUpdateManager->processGameUpdate(_stardustContainer, _planet, _opponent_planets, dimen);
-        for (int ii = 0; ii < _opponent_planets.size() ; ii++) {
-            std::shared_ptr<OpponentPlanet> opponent = _opponent_planets[ii];
-            if (opponent != nullptr && getChildByName(to_string(ii)) == nullptr) {
-                opponent->setTextures(_assets->get<Texture>("opponentProgress"), _assets->get<Texture>("fog"), dimen);
-                //TODO: call opponent->setName with name and font
-                addChildWithName(opponent->getOpponentNode(), to_string(ii));
-            }
-            
+        _gameUpdateManager->processGameUpdate(_stardustContainer, _planet, _opponentPlanets, dimen);
+        for (int ii = 0; ii < _opponentPlanets.size() ; ii++) {
+            std::shared_ptr<OpponentPlanet> opponent = _opponentPlanets[ii];
             if (opponent != nullptr) {
                 opponent->update(timestep);
             }
@@ -282,7 +288,7 @@ void GameScene::addStardust(const Size bounds) {
     /** Finds the average mass of the planets in game */
     int avgMass = _planet->getMass();
     int planetCount = 1;
-    for (const std::shared_ptr<OpponentPlanet> &op : _opponent_planets){
+    for (const std::shared_ptr<OpponentPlanet> &op : _opponentPlanets){
         if (op != nullptr){
             avgMass += op->getMass();
             planetCount++;
@@ -324,7 +330,7 @@ void GameScene::addStardust(const Size bounds) {
     /** Looparound Mechanism: Tries to make it so that players can't just send it straight back */
     int cornerProb[] = {10,10,10,10};
     CILocation::Value spawnCorner = CILocation::Value(0);
-    for (const std::shared_ptr<OpponentPlanet> &op : _opponent_planets){
+    for (const std::shared_ptr<OpponentPlanet> &op : _opponentPlanets){
         if (op != nullptr){
             if (op->getColor() == c){
                 cornerProb[op->getLocation()-1] += 60;
@@ -376,7 +382,7 @@ void GameScene::processSpecialStardust(const cugl::Size bounds, const std::share
                 break;
             case StardustModel::Type::FOG: {
                 CULog("FOG");
-                std::shared_ptr<OpponentPlanet> opponent = _opponent_planets[stardust->getPreviousOwner()];
+                std::shared_ptr<OpponentPlanet> opponent = _opponentPlanets[stardust->getPreviousOwner()];
                 if (opponent != nullptr) {
                     opponent->getOpponentNode()->applyFogPower();
                 }

--- a/source/CIGameScene.h
+++ b/source/CIGameScene.h
@@ -81,7 +81,7 @@ protected:
     /** Pointer to the model of the stardust that is currently being dragged */
     StardustModel*  _draggedStardust;
     /** Vector of opponent planets */
-    std::vector<std::shared_ptr<OpponentPlanet>> _opponent_planets;
+    std::vector<std::shared_ptr<OpponentPlanet>> _opponentPlanets;
 
     // Game Settings
     std::shared_ptr<GameSettings> _gameSettings;

--- a/source/CIGameUpdateManager.cpp
+++ b/source/CIGameUpdateManager.cpp
@@ -59,7 +59,7 @@ bool GameUpdateManager::init() {
  * @param stardustQueue     A reference to the player's stardust queue
  * @param bounds                    The bounds of the screen
  */
-void GameUpdateManager::sendUpdate(const std::shared_ptr<PlanetModel> planet, const std::shared_ptr<StardustQueue> stardustQueue, cugl::Size bounds) {
+void GameUpdateManager::sendUpdate(const std::shared_ptr<PlanetModel> planet, const std::shared_ptr<StardustQueue> stardustQueue) {
     if (getPlayerId() < 0) {
         return;
     }
@@ -130,7 +130,7 @@ void GameUpdateManager::processGameUpdate(std::shared_ptr<StardustQueue> stardus
         std::shared_ptr<GameUpdate> gameUpdate = _game_updates_to_process[ii];
         if (gameUpdate == nullptr) break;
         std::map<int, std::vector<std::shared_ptr<StardustModel>>> stardustSent = gameUpdate->getStardustSent();
-        CILocation::Value opponentLocation = NetworkUtils::getStardustLocation(getPlayerId(), gameUpdate->getPlayerId());
+        CILocation::Value opponentLocation = NetworkUtils::getLocation(getPlayerId(), gameUpdate->getPlayerId());
         if (stardustSent.count(getPlayerId()) > 0) {
             std::vector<std::shared_ptr<StardustModel>> stardustVector = stardustSent[getPlayerId()];
             for (size_t jj = 0; jj < stardustVector.size(); jj++) {
@@ -144,7 +144,7 @@ void GameUpdateManager::processGameUpdate(std::shared_ptr<StardustQueue> stardus
                 
                 // this player hit another player with a stardust
                 if (stardust->getColor() == CIColor::getNoneColor()) {
-                    opponentPlanets[gameUpdate->getPlayerId()]->startHitAnimation();
+                    opponentPlanets[NetworkUtils::getLocation(getPlayerId(), gameUpdate->getPlayerId())-1]->startHitAnimation();
                     
                     CIColor::Value c = planet->getColor() == CIColor::getNoneColor() ? CIColor::getRandomColor() : planet->getColor();
 
@@ -223,12 +223,8 @@ void GameUpdateManager::processGameUpdate(std::shared_ptr<StardustQueue> stardus
         }
         
         int playerId = gameUpdate->getPlayerId();
-        if (opponentPlanets[playerId] == nullptr) {
-            cugl::Vec2 pos = CILocation::getPositionOfLocation(planet->getLocation(), bounds);
-            opponentPlanets[playerId] = OpponentPlanet::alloc(pos.x, pos.y, planet->getColor(), planet->getLocation());
-        }
-        opponentPlanets[playerId]->setColor(planet->getColor());
-        opponentPlanets[playerId]->setMass(planet->getMass());
+        opponentPlanets[NetworkUtils::getLocation(getPlayerId(), playerId)-1]->setColor(planet->getColor());
+        opponentPlanets[NetworkUtils::getLocation(getPlayerId(), playerId)-1]->setMass(planet->getMass());
     }
     
     _game_updates_to_process.clear();

--- a/source/CIGameUpdateManager.h
+++ b/source/CIGameUpdateManager.h
@@ -124,7 +124,7 @@ public:
      * @param stardustQueue     A reference to the player's stardust queue
      * @param bounds                    The bounds of the screen
      */
-    void sendUpdate(const std::shared_ptr<PlanetModel> planet, const std::shared_ptr<StardustQueue> stardustQueue, cugl::Size bounds);
+    void sendUpdate(const std::shared_ptr<PlanetModel> planet, const std::shared_ptr<StardustQueue> stardustQueue);
     
     /**
      * Processes current game updates from other players if there are any.

--- a/source/CILobbyMenu.cpp
+++ b/source/CILobbyMenu.cpp
@@ -32,11 +32,9 @@ void LobbyMenu::dispose() {
     _winMassBtn = nullptr;
 
     _lobbyRoomLabel = nullptr;
-    _gamelobbyplayerlabel1 = nullptr;
-    _gamelobbyplayerlabel2 = nullptr;
-    _gamelobbyplayerlabel3 = nullptr;
-    _gamelobbyplayerlabel4 = nullptr;
-    _gamelobbyplayerlabel5 = nullptr;
+    for (int ii = 0; ii < _gameLobbyPlayerLabels.size(); ii++) {
+        _gameLobbyPlayerLabels[ii] = nullptr;
+    }
 
     _gamelobbyplayerName1 = nullptr;
     _gamelobbyplayerName2 = nullptr;
@@ -88,11 +86,12 @@ bool LobbyMenu::init(const std::shared_ptr<cugl::AssetManager>& assets,
     _gamelobbyplayerName3 = assets->get<scene2::SceneNode>("lobby_playerlabel3");
     _gamelobbyplayerName4 = assets->get<scene2::SceneNode>("lobby_playerlabel4");
     _gamelobbyplayerName5 = assets->get<scene2::SceneNode>("lobby_playerlabel5");
-    _gamelobbyplayerlabel1 = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_playerlabel1_label"));
-    _gamelobbyplayerlabel2 = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_playerlabel2_label"));
-    _gamelobbyplayerlabel3 = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_playerlabel3_label"));
-    _gamelobbyplayerlabel4 = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_playerlabel4_label"));
-    _gamelobbyplayerlabel5 = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_playerlabel5_label"));
+    _gameLobbyPlayerLabels.resize(5);
+    _gameLobbyPlayerLabels[0] = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_playerlabel1_label"));
+    _gameLobbyPlayerLabels[1] = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_playerlabel2_label"));
+    _gameLobbyPlayerLabels[2] = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_playerlabel3_label"));
+    _gameLobbyPlayerLabels[3] = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_playerlabel4_label"));
+    _gameLobbyPlayerLabels[4] = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_playerlabel5_label"));
 
     // Game lobby settings 
     _spawnRateLabel = std::dynamic_pointer_cast<scene2::Label>(assets->get<scene2::SceneNode>("lobby_spawnratebutton_up_label"));
@@ -220,7 +219,6 @@ void LobbyMenu::update(MenuState& state) {
     if (_layer == nullptr) {
         return;
     }
-    vector<string> othernames = { "N/A", "N/A", "N/A", "N/A" };;
     // handle GameLobby menu
     switch (state)
     {
@@ -229,7 +227,7 @@ void LobbyMenu::update(MenuState& state) {
             // handle displaying for Host
             _networkMessageManager->createGame();
             _networkMessageManager->setPlayerName(_playerSettings->getPlayerName());
-            _networkMessageManager->setOtherNames(othernames);
+            _networkMessageManager->setOtherNames({ "", "", "", "" });
             _networkMessageManager->sendMessages();
             _networkMessageManager->receiveMessages();
             _gameSettings->setGameId(_networkMessageManager->getRoomId());
@@ -238,7 +236,7 @@ void LobbyMenu::update(MenuState& state) {
             setDisplay(true);
 
             _lobbyRoomLabel->setText(_gameSettings->getGameId());
-            _gamelobbyplayerlabel1->setText(_playerSettings->getPlayerName());
+            _gameLobbyPlayerLabels[0]->setText(_playerSettings->getPlayerName());
 
             // handle game lobby settings (only visible to the host)
             _spawnRateLabel->setText(cugl::strtool::to_string(_gameSettings->getSpawnRate(), 1) + "X");
@@ -265,13 +263,13 @@ void LobbyMenu::update(MenuState& state) {
             _gamelobbyplayerName5->setPositionY(_gamelobbyplayerName5->getPositionY() - clientOffset);
 
             _networkMessageManager->setPlayerName(_playerSettings->getPlayerName());
-            _networkMessageManager->setOtherNames(othernames);
+            _networkMessageManager->setOtherNames({ "", "", "", "" });
             _networkMessageManager->joinGame(_gameSettings->getGameId());
             _networkMessageManager->setRoomID(_gameSettings->getGameId());
             _networkMessageManager->sendMessages();
             _networkMessageManager->receiveMessages();
             _lobbyRoomLabel->setText(_gameSettings->getGameId());
-            _gamelobbyplayerlabel1->setText(_playerSettings->getPlayerName());
+            _gameLobbyPlayerLabels[0]->setText(_playerSettings->getPlayerName());
             
             _isHost = false;
             state = MenuState::GameLobby;
@@ -283,13 +281,13 @@ void LobbyMenu::update(MenuState& state) {
             _networkMessageManager->sendMessages();
             _networkMessageManager->receiveMessages();
             _lobbyRoomLabel->setText(_networkMessageManager->getRoomId());
-            othernames = _networkMessageManager->getOtherNames();
+            vector<string> othernames = _networkMessageManager->getOtherNames();
             // update other players' labels
-            _gamelobbyplayerlabel2->setText(othernames.at(0));
-            _gamelobbyplayerlabel3->setText(othernames.at(1));
-            _gamelobbyplayerlabel4->setText(othernames.at(2));
-            _gamelobbyplayerlabel5->setText(othernames.at(3));
-
+            for (int ii = 0; ii < othernames.size(); ii++) {
+                if (othernames[ii] != "") {
+                    _gameLobbyPlayerLabels[ii+1]->setText(othernames[ii]);
+                }
+            }
             // handle room player updates and triggering game start
             if (_networkMessageManager->getGameState() == GameState::GameInProgress) {
                 _nextState = MenuState::LobbyToGame;

--- a/source/CILobbyMenu.h
+++ b/source/CILobbyMenu.h
@@ -51,11 +51,7 @@ private:
     std::shared_ptr<cugl::scene2::SceneNode> _gamelobbyplayerName3;
     std::shared_ptr<cugl::scene2::SceneNode> _gamelobbyplayerName4;
     std::shared_ptr<cugl::scene2::SceneNode> _gamelobbyplayerName5;
-    std::shared_ptr<cugl::scene2::Label> _gamelobbyplayerlabel1; // top
-    std::shared_ptr<cugl::scene2::Label> _gamelobbyplayerlabel2; // middle left
-    std::shared_ptr<cugl::scene2::Label> _gamelobbyplayerlabel3; // middle right
-    std::shared_ptr<cugl::scene2::Label> _gamelobbyplayerlabel4; // bottom left
-    std::shared_ptr<cugl::scene2::Label> _gamelobbyplayerlabel5; // bottom right
+    std::vector<std::shared_ptr<cugl::scene2::Label>> _gameLobbyPlayerLabels;
 
     // game lobby settings
     /** Reference to stardust spawn rate button + label + value list */

--- a/source/CIMenuScene.cpp
+++ b/source/CIMenuScene.cpp
@@ -86,8 +86,6 @@ bool MenuScene::init(const std::shared_ptr<cugl::AssetManager>& assets,
     // player settings
     _playerSettings = playerSettings;
 
-    _otherNames = vector<string>{ "N/A", "N/A", "N/A", "N/A" };
-
     _state = MenuState::LoadToMain;
 
     Application::get()->setClearColor(Color4(192, 192, 192, 255));

--- a/source/CIMenuScene.h
+++ b/source/CIMenuScene.h
@@ -64,8 +64,6 @@ protected:
 
     /** Stores the game code for joining as client*/
     string _joinGame;
-    /** Value for other players' names */
-    vector<string> _otherNames;
 
     // Menu scene state value
     MenuState _state;

--- a/source/CINetworkMessageManager.cpp
+++ b/source/CINetworkMessageManager.cpp
@@ -268,7 +268,12 @@ void NetworkMessageManager::receiveMessages() {
 
                 CULog("RCVD PLAYERNAME> PLAYERNAME[%s], PLAYER[%i], TS[%i]", player_name.c_str(), playerId, timestamp);
 
-                _otherNames.insert(_otherNames.begin() + playerId - 1, player_name);
+                if (playerId > getPlayerId()) {
+                    _otherNames[(playerId - 1)] = player_name;
+                }
+                else {
+                    _otherNames[playerId] = player_name;
+                }
 
                 std::vector<uint8_t> data;
                 NetworkUtils::encodeInt(NetworkUtils::MessageType::NameReceivedResponse, data);

--- a/source/CINetworkMessageManager.cpp
+++ b/source/CINetworkMessageManager.cpp
@@ -217,7 +217,7 @@ void NetworkMessageManager::receiveMessages() {
                 
                 CULog("RCVD PU> SRC[%i], CLR[%i], SIZE[%f]", srcPlayer, planetColor, planetSize);
                 
-                CILocation::Value corner = NetworkUtils::getStardustLocation(getPlayerId(), srcPlayer);
+                CILocation::Value corner = NetworkUtils::getLocation(getPlayerId(), srcPlayer);
                 std::shared_ptr<OpponentPlanet> planet = OpponentPlanet::alloc(0, 0, CIColor::Value(planetColor), corner);
                 planet->setMass(planetSize);
                 std::map<int, std::vector<std::shared_ptr<StardustModel>>> map = {};

--- a/source/CINetworkUtils.cpp
+++ b/source/CINetworkUtils.cpp
@@ -88,7 +88,7 @@ void NetworkUtils::encodeInt(int x, std::vector<uint8_t>& out) {
 /**
  * Gets the stardust location given our player id and the player id of the opponent.
  */
-CILocation::Value NetworkUtils::getStardustLocation(int playerID, int opponentPlayerID) {
+CILocation::Value NetworkUtils::getLocation(int playerID, int opponentPlayerID) {
     int location = (opponentPlayerID < playerID ? opponentPlayerID + 1 : opponentPlayerID);
     return CILocation::Value(location);
 }

--- a/source/CINetworkUtils.h
+++ b/source/CINetworkUtils.h
@@ -85,7 +85,7 @@ public:
     /**
      * Gets the stardust location given our player id and the player id of the opponent.
      */
-    static CILocation::Value getStardustLocation(int playerID, int opponentPlayerID);
+    static CILocation::Value getLocation(int playerID, int opponentPlayerID);
     
     /**
      * Returns an opponents player id given this player's id and a location

--- a/source/CIOpponentNode.h
+++ b/source/CIOpponentNode.h
@@ -23,9 +23,9 @@
 #define PROGRESS_FLASH_START    65
 
 /** The x offset of the nametag from the corner of the screen */
-#define NAMETAG_X_OFFSET 45
+#define NAMETAG_X_OFFSET        40
 /** The y offset of the nametag from the corner of the screen */
-#define NAMETAG_Y_OFFSET 80
+#define NAMETAG_Y_OFFSET        40
 
 class OpponentNode : public cugl::scene2::AnimationNode {
 private:
@@ -103,6 +103,30 @@ private:
                 break;
             case CILocation::Value::ON_SCREEN: //this case should not occur
                 return 0;
+        }
+    }
+    
+    /**
+     * Helper function to get the anchor of the text node
+     *
+     * @param location The location of this opponent node
+     */
+    cugl::Vec2 getTextAnchorFromLocation(CILocation::Value location) {
+        switch (location) {
+            case CILocation::Value::TOP_LEFT:
+                return cugl::Vec2::ANCHOR_TOP_LEFT;
+                break;
+            case CILocation::Value::TOP_RIGHT:
+                return cugl::Vec2::ANCHOR_TOP_RIGHT;
+                break;
+            case CILocation::Value::BOTTOM_LEFT:
+                return cugl::Vec2::ANCHOR_BOTTOM_LEFT;
+                break;
+            case CILocation::Value::BOTTOM_RIGHT:
+                return cugl::Vec2::ANCHOR_BOTTOM_RIGHT;
+                break;
+            case CILocation::Value::ON_SCREEN: //this case should not occur
+                return cugl::Vec2::ANCHOR_CENTER;
         }
     }
     
@@ -225,10 +249,11 @@ public:
     void setName(std::string name, std::shared_ptr<cugl::Font> font) {
         if (_nameLabel == nullptr) {
             _nameLabel = cugl::scene2::Label::alloc(name, font);
+            _nameLabel->setAnchor(getTextAnchorFromLocation(_location));
             cugl::Vec2 pos = getReflectFromLocation(_location) * cugl::Vec2(NAMETAG_X_OFFSET, NAMETAG_Y_OFFSET);
             _nameLabel->setPosition(pos);
             _nameLabel->setRelativeColor(false);
-            _nameLabel->setForeground(cugl::Color4::WHITE);
+            _nameLabel->setForeground(cugl::Color4(192, 192, 192, 192));
             addChild(_nameLabel);
         } else {
             _nameLabel->setText(name);


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Core Impact Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

This PR refactors the creation of OpponentPlanets to occur at the start of the game, rather than when the first planet update is received from a player. Also, it passes in the player names to each OpponentPlanet to be displayed on the screen.

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

* OpponentNodes are now created in the init() method of GameScene
* Name labels for the lobby are now stored in a vector, rather than as separate fields in LobbyMenu
* otherNames no longer uses "N/A", as the default label text is set in menu.json 
* Removed and renamed some fields and functions

## Next Steps 

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

* The field to change your name needs to be edited to prevent the empty string as your name.

## Screenshots 

<!-- If you are making any changes to UI, you should use this section. -->

<details>

  <summary>Opponent names displaying</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
  
<img width="1024" alt="Screen Shot 2021-04-28 at 1 15 51 PM" src="https://user-images.githubusercontent.com/40394622/116449552-4a154c00-a828-11eb-97f9-e6f8e517e899.png">


</details>