### PR TITLE
Fix bug where a powerup from player 4 would crash your game

### DIFF
--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -22,6 +22,7 @@
 
 #include "CIGameScene.h"
 #include "CICollisionController.h"
+#include "CINetworkUtils.h"
 
 using namespace cugl;
 using namespace std;
@@ -377,7 +378,8 @@ void GameScene::processSpecialStardust(const cugl::Size bounds, const std::share
                 break;
             case StardustModel::Type::FOG: {
                 CULog("FOG");
-                std::shared_ptr<OpponentPlanet> opponent = _opponentPlanets[stardust->getPreviousOwner()];
+                int ii = NetworkUtils::getLocation(_gameUpdateManager->getPlayerId(), stardust->getPreviousOwner())-1;
+                std::shared_ptr<OpponentPlanet> opponent = _opponentPlanets[ii];
                 if (opponent != nullptr) {
                     opponent->getOpponentNode()->applyFogPower();
                 }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Core Impact Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Quick PR to fix a crash scenario where a powerup from player 4 could crash your game 
