### PR TITLE
switched z order of win screen

### DIFF
--- a/assets/json/assets.json
+++ b/assets/json/assets.json
@@ -89,7 +89,7 @@
             "y_offset": 0.2
           }
         },
-	      "pausebutton": {
+          "pausebutton": {
           "comment": "The pause button with 3 dots in a circle.",
           "type": "Widget",
           "data": {
@@ -98,69 +98,69 @@
           "layout": {
             "x_anchor": "center",
             "y_anchor": "top",
-	          "y_offset": -0.1
+              "y_offset": -0.1
+          }
+        }
+      }
+    },
+    "win": {
+      "type": "Node",
+      "format": {
+        "type": "Anchored"
+      },
+      "children": {
+        "gameOutcomeLabel": {
+          "comment": "The text label showing the outcome of the game",
+          "type": "Label",
+          "data": {
+            "font": "saira32",
+            "text": "",
+            "foreground": [255, 255, 255, 255],
+            "background": [0, 0, 0, 0],
+            "size": [200, 80],
+            "anchor": [0.5, 0.5],
+            "halign": "center",
+            "valign": "middle",
+            "visible": false
+          },
+          "layout": {
+            "x_anchor": "center",
+            "y_anchor": "middle",
+            "y_offset": 0.4
           }
         },
-        "win": {
-          "type": "Node",
-          "format": {
-            "type": "Anchored"
-          },
-          "children": {
-            "gameOutcomeLabel": {
-              "comment": "The text label showing the outcome of the game",
-              "type": "Label",
-              "data": {
-                "font": "saira32",
-                "text": "",
-                "foreground": [255, 255, 255, 255],
-                "background": [0, 0, 0, 0],
-                "size": [200, 80],
-                "anchor": [0.5, 0.5],
-                "halign": "center",
-                "valign": "middle",
-                "visible": false
-              },
-              "layout": {
-                "x_anchor": "center",
-                "y_anchor": "middle",
-                "y_offset": 0.4
-              }
-            },
-            "backToHomeButton": {
-              "comment": "The button that brings a player back to the home screen",
-              "type": "Widget",
-              "data": {
-                  "key": "clearbutton",
-                  "variables" : {
-                      "size"  : [200,200],
-                      "text"  : "Back to Home"
-                  }
-              },
-              "layout": {
-                "x_anchor": "center",
-                "y_anchor": "middle",
-                "x_offset": -0.2,
-                "y_offset": 0.2
-              }
-            },
-            "newGameButton": {
-              "comment": "The button that brings a player to the new game screen",
-              "type": "Widget",
-              "data": {
-                "key": "clearbutton",
-                "variables" : {
+        "backToHomeButton": {
+          "comment": "The button that brings a player back to the home screen",
+          "type": "Widget",
+          "data": {
+              "key": "clearbutton",
+              "variables" : {
                   "size"  : [200,200],
-                  "text"  : "New Game"
-                }
-              },
-              "layout": {
-                "x_anchor": "center",
-                "y_anchor": "middle",
-                "x_offset": 0.2,
-                "y_offset": 0.2
+                  "text"  : "Back to Home"
               }
+          },
+          "layout": {
+            "x_anchor": "center",
+            "y_anchor": "middle",
+            "x_offset": -0.2,
+            "y_offset": 0.2
+          }
+        },
+        "newGameButton": {
+          "comment": "The button that brings a player to the new game screen",
+          "type": "Widget",
+          "data": {
+            "key": "clearbutton",
+            "variables" : {
+              "size"  : [200,200],
+              "text"  : "New Game"
             }
+          },
+          "layout": {
+            "x_anchor": "center",
+            "y_anchor": "middle",
+            "x_offset": 0.2,
+            "y_offset": 0.2
           }
         }
       }

--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -131,6 +131,7 @@ bool GameScene::init(const std::shared_ptr<cugl::AssetManager>& assets,
     addChild(_planet->getPlanetNode());
     addChild(_stardustContainer->getStardustNode());
     addChild(_pauseMenu->getLayer(), 1);
+    addChild(_winScene->getLayer(), 1);
     
     std::vector<string> opponentNames = networkMessageManager->getOtherNames();
     _opponentPlanets.resize((int) opponentNames.size());
@@ -165,7 +166,10 @@ void GameScene::dispose() {
     else if (_pauseBtn != nullptr) {
         _pauseBtn->clearListeners();
     }
-    _pauseMenu->dispose();
+    
+    if (_pauseMenu != nullptr) {
+        _pauseMenu->dispose();
+    }
 
     _assets = nullptr;
     _gameUpdateManager = nullptr;
@@ -202,6 +206,10 @@ void GameScene::update(float timestep) {
     if (_networkMessageManager->getWinnerPlayerId() != -1) {
         if (!_winScene->displayActive()) {
             CULog("Game won.");
+            Color4 color = CIColor::getColor4(_planet->getColor());
+            color.a = 75;
+            _planet->getPlanetNode()->setColor(color);
+            _pauseBtn->setVisible(false);
             int winnerId = _networkMessageManager->getWinnerPlayerId();
             std::string winningPlayer = _networkMessageManager->getOtherNames()[winnerId > _networkMessageManager->getPlayerId() ? winnerId - 1 : winnerId];
             _winScene->setWinner(_networkMessageManager->getWinnerPlayerId(), _networkMessageManager->getPlayerId(), winningPlayer);
@@ -276,7 +284,7 @@ void GameScene::update(float timestep) {
     togglePause(_networkMessageManager->getGameState() == GameState::GamePaused);
     _pauseMenu->update();
     if (_pauseMenu->getExitGame()){
-        _winScene->setDisplay(false);
+        _pauseMenu->setDisplay(false);
         setActive(false);
     }
 }

--- a/source/CINetworkMessageManager.cpp
+++ b/source/CINetworkMessageManager.cpp
@@ -289,6 +289,9 @@ void NetworkMessageManager::receiveMessages() {
             }
             else if (message_type == NetworkUtils::MessageType::NameSent) {
                 string player_name = NetworkUtils::decodeString(recv[4], recv[5], recv[6], recv[7], recv[8], recv[9], recv[10], recv[11], recv[12], recv[13], recv[14], recv[15]);
+                player_name.erase(std::find_if(player_name.rbegin(), player_name.rend(), [](unsigned char ch) {
+                        return ch != '\0';
+                    }).base(), player_name.end());
                 int playerId = NetworkUtils::decodeInt(recv[16], recv[17], recv[18], recv[19]);
                 int timestamp = NetworkUtils::decodeInt(recv[20], recv[21], recv[22], recv[23]);
 

--- a/source/CIWinScene.cpp
+++ b/source/CIWinScene.cpp
@@ -37,12 +37,13 @@ void WinScene::dispose() {
  * @return true if initialization was successful, false otherwise
  */
 bool WinScene::init(const std::shared_ptr<cugl::AssetManager>& assets, cugl::Size dimen) {
-    auto win = assets->get<cugl::scene2::SceneNode>("game_win");
+    auto win = assets->get<cugl::scene2::SceneNode>("win");
+    _layer = win;
     win->setContentSize(dimen);
     win->doLayout();
     
-    _gameOutcomeLabel = std::dynamic_pointer_cast<cugl::scene2::Label>(assets->get<cugl::scene2::SceneNode>("game_win_gameOutcomeLabel"));
-    _backToHomeButton = std::dynamic_pointer_cast<cugl::scene2::Button>(assets->get<cugl::scene2::SceneNode>("game_win_backToHomeButton"));
+    _gameOutcomeLabel = std::dynamic_pointer_cast<cugl::scene2::Label>(assets->get<cugl::scene2::SceneNode>("win_gameOutcomeLabel"));
+    _backToHomeButton = std::dynamic_pointer_cast<cugl::scene2::Button>(assets->get<cugl::scene2::SceneNode>("win_backToHomeButton"));
     _backToHomeButton->addListener([&](const std::string& name, bool down) {
         if (!down) {
             _goBackToHome = true;
@@ -50,7 +51,7 @@ bool WinScene::init(const std::shared_ptr<cugl::AssetManager>& assets, cugl::Siz
     });
     
     // TODO: change this listener
-    _newGameButton = std::dynamic_pointer_cast<cugl::scene2::Button>(assets->get<cugl::scene2::SceneNode>("game_win_newGameButton"));
+    _newGameButton = std::dynamic_pointer_cast<cugl::scene2::Button>(assets->get<cugl::scene2::SceneNode>("win_newGameButton"));
     _newGameButton->addListener([&](const std::string& name, bool down) {
         if (!down) {
             _goBackToHome = true;
@@ -71,9 +72,6 @@ void WinScene::setWinner(int winnerPlayerId, int playerId, std::string winningPl
     if (winnerPlayerId == playerId) {
         _gameOutcomeLabel->setText("Congratulations! You won the game!");
     } else {
-        winningPlayer.erase(std::find_if(winningPlayer.rbegin(), winningPlayer.rend(), [](unsigned char ch) {
-                return ch != '\0';
-            }).base(), winningPlayer.end());
         _gameOutcomeLabel->setText("Sorry! " + winningPlayer + " won the game.");
     }
 }

--- a/source/CIWinScene.h
+++ b/source/CIWinScene.h
@@ -15,6 +15,8 @@
 
 class WinScene {
 private:
+    /** Reference to the node for the group representing this win scene */
+    std::shared_ptr<cugl::scene2::SceneNode> _layer;
     /** Label that displays the outcome of the game. */
     std::shared_ptr<cugl::scene2::Label> _gameOutcomeLabel;
     /** Button that brings a player back to the home screen. */
@@ -109,6 +111,16 @@ public:
     bool goBackToHome() {
         return _goBackToHome;
     }
+    
+    /**
+     * Returns the root scene node for the win screen layer.
+     *
+     * @return a shared pointer to the win screen layer root scene node
+     */
+    const std::shared_ptr<cugl::scene2::SceneNode>& getLayer() const {
+        return _layer;
+    }
+
 };
 
 #endif /* __CI_WIN_SCENE_H__ */


### PR DESCRIPTION
## Overview

A couple minor fixes 


## Changes Made

- fixed win screen z-order, decreased alpha value of planet when game ends and remove pause button when game ends
- fixed bug that caused null pointer exception when exiting game after a game has started
- whitespace trimmed from names when player names are received


## Screenshots
<img width="1021" alt="Screen Shot 2021-05-04 at 10 12 03 PM" src="https://user-images.githubusercontent.com/14276502/117090330-15bcf680-ad26-11eb-9fe3-d425341384fc.png">


