### PR TITLE
start button shows up

### DIFF
--- a/assets/json/menu.json
+++ b/assets/json/menu.json
@@ -68,7 +68,7 @@
     },
     "saira32": {
       "file": "fonts/gillsans.ttf",
-      "size": 32
+      "size": 28
     },
     "saira24": {
       "file": "fonts/gillsans.ttf",


### PR DESCRIPTION
## Overview

I think the issue was the new font is a bit too big to fit in the submenubutton. This is the easiest change I could make for fixing this. I tried playing around with the actual size of the button and it didn't really do much


## Screenshots (delete if not applicable)

<img width="1025" alt="Screen Shot 2021-05-18 at 12 32 25 PM" src="https://user-images.githubusercontent.com/14276502/118689622-36c92100-b7d5-11eb-8aa4-60af5047cb92.png">
