### PR TITLE
Fixed Name Menu 

### DIFF
--- a/assets/json/menu.json
+++ b/assets/json/menu.json
@@ -19,9 +19,9 @@
       "minfilter": "linear",
       "magfilter": "linear"
     },
-    "gamesettingsbutton":{
-        "file": "textures/more_options.png",
-        "wrapS": "clamp"
+    "gamesettingsbutton": {
+      "file": "textures/more_options.png",
+      "wrapS": "clamp"
     },
     "menubuttonup": {
       "file": "textures/nine_patch.png",
@@ -292,7 +292,7 @@
           "comment": "The border around the current game room id",
           "type": "Widget",
           "data": {
-              "key": "lobbycode"
+            "key": "lobbycode"
           },
           "layout": {
             "x_anchor": "center",
@@ -381,7 +381,7 @@
             "variables": {
               "texture": "gamesettingsbutton",
               "scale": 0.7,
-              "size": [40,40]
+              "size": [40, 40]
             }
           },
           "layout": {
@@ -630,25 +630,6 @@
             "y_offset": 0.38
           }
         },
-        "subtitle": {
-          "type": "Label",
-          "data": {
-            "font": "saira24",
-            "text": "Your name will be saved for future games.",
-            "foreground": [255, 255, 255, 255],
-            "background": [0, 0, 0, 0],
-            "size": [300, 80],
-            "anchor": [0.5, 0.5],
-            "halign": "center",
-            "valign": "middle",
-            "visible": false
-          },
-          "layout": {
-            "x_anchor": "center",
-            "y_anchor": "middle",
-            "y_offset": 0.28
-          }
-        },
         "nameinput": {
           "comment": "The player name text input in Settings.",
           "type": "Widget",
@@ -665,11 +646,11 @@
           "comment": "Number pad Join",
           "type": "Widget",
           "data": {
-            "key": "lobbyimagebutton",
+            "key": "checkmarkbutton",
             "variables": {
               "size": [75, 75],
               "texture": "joinbutton",
-              "scale": 1.4,
+              "scale": 1,
               "xoffset": -0.2,
               "yoffset": -0.15
             }
@@ -677,8 +658,27 @@
           "layout": {
             "x_anchor": "center",
             "y_anchor": "middle",
-            "x_offset": 0.34,
+            "x_offset": 0.2,
             "y_offset": 0.05
+          }
+        },
+        "subtitle": {
+          "type": "Label",
+          "data": {
+            "font": "saira24",
+            "text": "Your name will be saved for future games.",
+            "foreground": [255, 255, 255, 255],
+            "background": [0, 0, 0, 0],
+            "size": [300, 80],
+            "anchor": [0.5, 0.5],
+            "halign": "center",
+            "valign": "middle",
+            "visible": false
+          },
+          "layout": {
+            "x_anchor": "center",
+            "y_anchor": "middle",
+            "y_offset": -0.15
           }
         }
       }
@@ -1326,7 +1326,7 @@
             "range": [0, 1],
             "value": 0.5,
             "anchor": [0.5, 0.5],
-            "scale": 0.70,
+            "scale": 0.7,
             "visible": false,
             "knob": {
               "type": "Button",

--- a/source/CIMainMenu.cpp
+++ b/source/CIMainMenu.cpp
@@ -132,6 +132,7 @@ void MainMenu::update(MenuState& state) {
     // handle MainMenu
     switch (state) 
     {
+        case MenuState::NameToMain:
         case MenuState::SettingToMain:
         case MenuState::JoinToMain:
         case MenuState::LobbyToMain:

--- a/source/CINameMenu.cpp
+++ b/source/CINameMenu.cpp
@@ -125,8 +125,9 @@ void NameMenu::update(MenuState& state) {
     switch (state)
     {
         case MenuState::MainToName:
-            if (!_playerSettings->getIsNew()) {
+            if (!_playerSettings->getIsNeedName()) {
                 // skip to join menu
+                CULog("SKip to join menu");
                 state = _nextState = MenuState::MainToJoin;
                 break;
             }

--- a/source/CINameMenu.cpp
+++ b/source/CINameMenu.cpp
@@ -125,9 +125,8 @@ void NameMenu::update(MenuState& state) {
     switch (state)
     {
         case MenuState::MainToName:
-            if (!_playerSettings->getIsNeedName()) {
+            if (_playerSettings->getSkipNameMenu()) {
                 // skip to join menu
-                CULog("SKip to join menu");
                 state = _nextState = MenuState::MainToJoin;
                 break;
             }

--- a/source/CIPlayerSettings.h
+++ b/source/CIPlayerSettings.h
@@ -143,8 +143,8 @@ public:
      * Used to check player name when transitioning from main menu screen to
      * the join or create menu screens. 
      */
-    bool getIsNeedName() const {
-        return (_isNew || _playerName.empty() || _playerName.size() > 12);
+    bool getSkipNameMenu() const {
+        return !(_isNew || _playerName.empty() || _playerName.size() > 12);
     }
 
 };

--- a/source/CIPlayerSettings.h
+++ b/source/CIPlayerSettings.h
@@ -137,6 +137,16 @@ public:
         return _isNew;
     }
 
+    /**
+     * Returns whether the player is new or player name is invalid.
+     * 
+     * Used to check player name when transitioning from main menu screen to
+     * the join or create menu screens. 
+     */
+    bool getIsNeedName() const {
+        return (_isNew || _playerName.empty() || _playerName.size() > 12);
+    }
+
 };
 
 #endif /* __CI_PLAYER_SETTINGS_H__ */


### PR DESCRIPTION
## Overview

Fixed the join check button display issue in name menu. Updated the line of text positioning in name menu to match the figma design. Fixed the navigation issue with back button from name menu. 

## Changes Made

- Updated the menu.json to fix the join check button display in name menu
- Updated the position of the line of text in name menu (above name input to below)
- Fixed navigation issue with back button from name menu 
- Name menu also handles invalid player name cases (name menu displayed in case of new player or invalid player name such as empty string)

## Screen Shots

- Name Menu 

![namemenu_update](https://user-images.githubusercontent.com/43297289/118877756-cf869c00-b8bc-11eb-9b87-423b08a26422.JPG)

