### PR TITLE
Lock in animation stops when the game ends

### DIFF
--- a/source/CIGameScene.cpp
+++ b/source/CIGameScene.cpp
@@ -238,6 +238,7 @@ void GameScene::update(float timestep, const std::shared_ptr<PlayerSettings>& pl
             if (_gameEndTimer == 360) {
                 CULog("Game won.");
                 _pauseBtn->setVisible(false);
+                _planet->stopLockIn();
                 int winnerId = _networkMessageManager->getWinnerPlayerId();
                 std::string winningPlayer = "A player";
                 if (winnerId >= 0) {

--- a/source/CITutorialScene.cpp
+++ b/source/CITutorialScene.cpp
@@ -237,6 +237,7 @@ void TutorialScene::update(float timestep, const std::shared_ptr<PlayerSettings>
             if (_gameEndTimer == 360) {
                 CULog("Game won.");
                 _pauseBtn->setVisible(false);
+                _planet->stopLockIn();
                 _winScene->setWinner(0, 0, "");
                 AudioEngine::get()->getMusicQueue()->pause();
                 if (_playerSettings->getMusicOn()) {


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Core Impact Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

This PR makes it so that the lock in animation stops when the game ends
