### PR TITLE
Remove new game button from win scene

### DIFF
--- a/assets/json/assets.json
+++ b/assets/json/assets.json
@@ -195,24 +195,8 @@
           "layout": {
             "x_anchor": "center",
             "y_anchor": "middle",
-            "x_offset": -0.2,
-            "y_offset": 0.2
-          }
-        },
-        "newGameButton": {
-          "comment": "The button that brings a player to the new game screen",
-          "type": "Widget",
-          "data": {
-            "key": "menubutton",
-            "variables" : {
-              "text"  : "New Game"
-            }
-          },
-          "layout": {
-            "x_anchor": "center",
-            "y_anchor": "middle",
-            "x_offset": 0.2,
-            "y_offset": 0.2
+            "x_offset": 0.0,
+            "y_offset": 0.3
           }
         },
         "flare": {

--- a/assets/json/assets.json
+++ b/assets/json/assets.json
@@ -196,7 +196,7 @@
             "x_anchor": "center",
             "y_anchor": "middle",
             "x_offset": 0.0,
-            "y_offset": 0.3
+            "y_offset": 0.275
           }
         },
         "flare": {

--- a/source/CITutorialScene.cpp
+++ b/source/CITutorialScene.cpp
@@ -673,7 +673,7 @@ void TutorialScene::addStardust(const Size bounds) {
  */
 void TutorialScene::processSpecialStardust(const cugl::Size bounds, const std::shared_ptr<StardustQueue> stardustQueue) {
     // avoid processing powerups after game is over
-    if (_tutorialStage == 13) {
+    if (_tutorialStage == 13 || _planet->isWinner()) {
         return;
     }
     std::vector<std::shared_ptr<StardustModel>> powerupQueue = stardustQueue->getPowerupQueue();

--- a/source/CIWinScene.cpp
+++ b/source/CIWinScene.cpp
@@ -16,15 +16,12 @@
 void WinScene::dispose() {
     if (_backToHomeButton != nullptr && _backToHomeButton->isActive()) {
         _backToHomeButton->deactivate();
-        _newGameButton->deactivate();
     } else if (_backToHomeButton != nullptr) {
         _backToHomeButton->clearListeners();
-        _newGameButton->clearListeners();
     }
     
     _gameOutcomeLabel = nullptr;
     _backToHomeButton = nullptr;
-    _newGameButton = nullptr;
     _flareExplosion = nullptr;
     _goBackToHome = false;
 }
@@ -47,14 +44,6 @@ bool WinScene::init(const std::shared_ptr<cugl::AssetManager>& assets, cugl::Siz
     _backToHomeButton = std::dynamic_pointer_cast<cugl::scene2::Button>(assets->get<cugl::scene2::SceneNode>("win_backToHomeButton"));
     _flareExplosion = std::dynamic_pointer_cast<cugl::scene2::SceneNode>(assets->get<cugl::scene2::SceneNode>("win_flare"));
     _backToHomeButton->addListener([&](const std::string& name, bool down) {
-        if (!down) {
-            _goBackToHome = true;
-        }
-    });
-    
-    // TODO: change this listener
-    _newGameButton = std::dynamic_pointer_cast<cugl::scene2::Button>(assets->get<cugl::scene2::SceneNode>("win_newGameButton"));
-    _newGameButton->addListener([&](const std::string& name, bool down) {
         if (!down) {
             _goBackToHome = true;
         }
@@ -90,13 +79,10 @@ void WinScene::setWinner(int winnerPlayerId, int playerId, std::string winningPl
 void WinScene::setDisplay(bool onDisplay) {
     _gameOutcomeLabel->setVisible(onDisplay);
     _backToHomeButton->setVisible(onDisplay);
-    _newGameButton->setVisible(onDisplay);
     
     if (onDisplay) {
         _backToHomeButton->activate();
-        _newGameButton->activate();
     } else {
         _backToHomeButton->deactivate();
-        _newGameButton->deactivate();
     }
 }

--- a/source/CIWinScene.h
+++ b/source/CIWinScene.h
@@ -21,8 +21,6 @@ private:
     std::shared_ptr<cugl::scene2::Label> _gameOutcomeLabel;
     /** Button that brings a player back to the home screen. */
     std::shared_ptr<cugl::scene2::Button> _backToHomeButton;
-    /** Button that starts a new game. */
-    std::shared_ptr<cugl::scene2::Button> _newGameButton;
     
     /** Flag variable to indicated whether to bring the user back to the home screen. */
     bool _goBackToHome;


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Core Impact Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

This PR removes the 'new game' button from the win scene, as it just brought you back to the menu. If we wanted to, we could add in the functionality to immediately start a new game, but I just wanted to get this out as a candidate PR to address this problem

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

* Removed new game button from win scene
* Centered the 'back to home' button and moved it up a bit
* Fixed a small problem in the tutorial where your powerup would be activated when you won the game

## Screenshots 

<!-- If you are making any changes to UI, you should use this section. -->

<details>

  <summary>New Win Scene</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
  
<img width="1024" alt="Screen Shot 2021-05-24 at 10 52 31 AM" src="https://user-images.githubusercontent.com/40394622/119366110-9e241c80-bc7e-11eb-84f1-3a694fe87713.png">


</details>